### PR TITLE
WPF デスクトップアプリを追加

### DIFF
--- a/.github/workflows/dotnet-build-and-publish.yml
+++ b/.github/workflows/dotnet-build-and-publish.yml
@@ -9,16 +9,74 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 #v6
+
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
       with:
         dotnet-version: '10.0.x'
+
+    - name: Get version
+      id: version
+      shell: pwsh
+      run: |
+        $props = [xml](Get-Content 'Directory.Build.props')
+        $version = $props.Project.PropertyGroup.VersionPrefix
+        if ([string]::IsNullOrWhiteSpace($version)) {
+          throw 'VersionPrefix is not defined in Directory.Build.props.'
+        }
+        "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
     - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore
-    - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet restore speech-translator.sln
+
+    - name: Build solution
+      run: dotnet build speech-translator.sln --configuration Release --no-restore
+
+    - name: Test solution
+      run: dotnet test speech-translator.sln --configuration Release --no-build --verbosity normal
+
+    - name: Publish Console
+      run: dotnet publish src/SpeechTranslatorConsole/SpeechTranslatorConsole.csproj --configuration Release --no-build --output artifacts/publish/console
+
+    - name: Publish Desktop
+      run: dotnet publish src/SpeechTranslatorDesktop/SpeechTranslatorDesktop.csproj --configuration Release --no-build --output artifacts/publish/desktop
+
+    - name: Package publish outputs
+      shell: pwsh
+      run: |
+        New-Item -ItemType Directory -Path artifacts/release -Force | Out-Null
+        Compress-Archive -Path artifacts/publish/console/* -DestinationPath "artifacts/release/speech-translator-console-${{ steps.version.outputs.version }}.zip" -Force
+        Compress-Archive -Path artifacts/publish/desktop/* -DestinationPath "artifacts/release/speech-translator-desktop-${{ steps.version.outputs.version }}.zip" -Force
+
+    - name: Upload publish artifacts
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7
+      with:
+        name: publish-${{ steps.version.outputs.version }}
+        path: artifacts/release/*.zip
+
+  release:
+    needs: build
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Download publish artifacts
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8
+      with:
+        name: publish-${{ needs.build.outputs.version }}
+        path: artifacts/release
+
+    - name: Create tag and release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh release create "${{ needs.build.outputs.version }}" artifacts/release/*.zip `
+          --title "${{ needs.build.outputs.version }}" `
+          --generate-notes `
+          --target "${{ github.sha }}"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>1.0.0</VersionPrefix>
+  </PropertyGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This app is speech translator and recorder using [Azure AI Speech](https://azure
 
 ## How to use
 
+### Console app
+
 1. Create Azure AI Speech resource. ([Bicep](./infra/main.bicep))
 2. Copy `Subscription Key` and `Region` from Azure Portal.
 3. Clone this repository.
@@ -23,6 +25,27 @@ This app is speech translator and recorder using [Azure AI Speech](https://azure
 6. Set the microphone device for translation as the default input device.
 7. Run `SpeechTranslatorConsole` project. (`dotnet run --project src/SpeechTranslatorConsole`)
 8. Type file name in console.
+
+### Desktop app (WPF)
+
+Desktop app reads Azure AI Speech credentials from environment variables only.
+
+1. Create Azure AI Speech resource. ([Bicep](./infra/main.bicep))
+2. Set the microphone device for translation as the default input device.
+3. Set environment variables in PowerShell.
+   ```powershell
+   $env:SPEECH_REGION="japaneast"
+   $env:SPEECH_KEY="your-speech-key"
+   ```
+4. Run the desktop project.
+   ```powershell
+   dotnet run --project src/SpeechTranslatorDesktop
+   ```
+5. Select the speaker language and target language.
+6. Optionally enter a simple recording file name stem (letters/numbers/`-`/`_`, no path or extension). If empty, no file is saved.
+7. Click `開始` to start and `停止` to stop.
+
+Recording files are saved as UTF-8 text files under `recordings/` relative to the desktop app executable directory.
 
 ## References
 

--- a/speech-translator.sln
+++ b/speech-translator.sln
@@ -17,9 +17,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ソリューション項目
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SpeechTranslatorShared", "src\Shared\SpeechTranslatorShared.csproj", "{FF0262A4-994A-4237-88E4-1049E03E85D3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SpeechTranslatorDesktop", "src\SpeechTranslatorDesktop\SpeechTranslatorDesktop.csproj", "{D3EEB803-3DC2-4F3C-A6C3-3FBD9CA8E5DE}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{00192D0A-A300-4EA4-A6BA-D193D73004D5}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SpeechTranslatorShared.Tests", "tests\Shared.Tests\SpeechTranslatorShared.Tests.csproj", "{EA08923B-519F-40CB-B219-4826FE0954F2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SpeechTranslator.Desktop.Tests", "tests\SpeechTranslator.Desktop.Tests\SpeechTranslator.Desktop.Tests.csproj", "{B0C1585E-A3A5-4C7B-9A70-B72593FD8575}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "infra", "infra", "{29895FE7-AC12-4776-8802-1143D61EE2D8}"
 	ProjectSection(SolutionItems) = preProject
@@ -41,10 +45,18 @@ Global
 		{FF0262A4-994A-4237-88E4-1049E03E85D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FF0262A4-994A-4237-88E4-1049E03E85D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FF0262A4-994A-4237-88E4-1049E03E85D3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D3EEB803-3DC2-4F3C-A6C3-3FBD9CA8E5DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D3EEB803-3DC2-4F3C-A6C3-3FBD9CA8E5DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D3EEB803-3DC2-4F3C-A6C3-3FBD9CA8E5DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D3EEB803-3DC2-4F3C-A6C3-3FBD9CA8E5DE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{EA08923B-519F-40CB-B219-4826FE0954F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EA08923B-519F-40CB-B219-4826FE0954F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EA08923B-519F-40CB-B219-4826FE0954F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EA08923B-519F-40CB-B219-4826FE0954F2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B0C1585E-A3A5-4C7B-9A70-B72593FD8575}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B0C1585E-A3A5-4C7B-9A70-B72593FD8575}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B0C1585E-A3A5-4C7B-9A70-B72593FD8575}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B0C1585E-A3A5-4C7B-9A70-B72593FD8575}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -52,7 +64,9 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{CFD1A73A-09D2-46F2-8E34-0247E0D19A5B} = {358DED3F-4540-44E2-993E-AA7BB7E61EE6}
 		{FF0262A4-994A-4237-88E4-1049E03E85D3} = {358DED3F-4540-44E2-993E-AA7BB7E61EE6}
+		{D3EEB803-3DC2-4F3C-A6C3-3FBD9CA8E5DE} = {358DED3F-4540-44E2-993E-AA7BB7E61EE6}
 		{EA08923B-519F-40CB-B219-4826FE0954F2} = {00192D0A-A300-4EA4-A6BA-D193D73004D5}
+		{B0C1585E-A3A5-4C7B-9A70-B72593FD8575} = {00192D0A-A300-4EA4-A6BA-D193D73004D5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2C0686D0-47ED-4A5B-A104-962D1DA98B29}

--- a/src/Shared/ITranslationSession.cs
+++ b/src/Shared/ITranslationSession.cs
@@ -1,0 +1,10 @@
+namespace SpeechTranslatorShared;
+
+public interface ITranslationSession : IAsyncDisposable
+{
+    Task Completion { get; }
+
+    bool IsRunning { get; }
+
+    Task StopAsync();
+}

--- a/src/Shared/TranslationSession.cs
+++ b/src/Shared/TranslationSession.cs
@@ -1,0 +1,122 @@
+namespace SpeechTranslatorShared;
+
+public sealed class TranslationSession : ITranslationSession
+{
+    private readonly AudioConfig _audioConfig;
+    private readonly TranslationRecognizer _recognizer;
+    private readonly TranslationRecognizerWorkerBase _worker;
+    private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _disposeRequested;
+    private int _stopRequested;
+    private bool _started;
+    private bool _disposed;
+
+    public TranslationSession(AudioConfig audioConfig, TranslationRecognizer recognizer, TranslationRecognizerWorkerBase worker)
+    {
+        _audioConfig = audioConfig ?? throw new ArgumentNullException(nameof(audioConfig));
+        _recognizer = recognizer ?? throw new ArgumentNullException(nameof(recognizer));
+        _worker = worker ?? throw new ArgumentNullException(nameof(worker));
+
+        _recognizer.Recognizing += OnRecognizing;
+        _recognizer.Recognized += OnRecognized;
+        _recognizer.Canceled += OnCanceled;
+        _recognizer.SpeechStartDetected += OnSpeechStartDetected;
+        _recognizer.SpeechEndDetected += OnSpeechEndDetected;
+        _recognizer.SessionStarted += OnSessionStarted;
+        _recognizer.SessionStopped += OnSessionStopped;
+    }
+
+    public Task Completion => _completion.Task;
+
+    public bool IsRunning { get; private set; }
+
+    public async Task StartAsync()
+    {
+        ThrowIfDisposed();
+
+        if (_started)
+        {
+            throw new InvalidOperationException("The translation session has already been started.");
+        }
+
+        _started = true;
+        await _recognizer.StartContinuousRecognitionAsync().ConfigureAwait(false);
+        IsRunning = true;
+    }
+
+    public async Task StopAsync()
+    {
+        ThrowIfDisposed();
+
+        if (!_started)
+        {
+            return;
+        }
+
+        if (Interlocked.Exchange(ref _stopRequested, 1) == 1)
+        {
+            await Completion.ConfigureAwait(false);
+            return;
+        }
+
+        await _recognizer.StopContinuousRecognitionAsync().ConfigureAwait(false);
+        Complete();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposeRequested, 1) == 1)
+        {
+            return;
+        }
+
+        if (_started)
+        {
+            await StopAsync().ConfigureAwait(false);
+        }
+
+        _recognizer.Recognizing -= OnRecognizing;
+        _recognizer.Recognized -= OnRecognized;
+        _recognizer.Canceled -= OnCanceled;
+        _recognizer.SpeechStartDetected -= OnSpeechStartDetected;
+        _recognizer.SpeechEndDetected -= OnSpeechEndDetected;
+        _recognizer.SessionStarted -= OnSessionStarted;
+        _recognizer.SessionStopped -= OnSessionStopped;
+        _recognizer.Dispose();
+        _audioConfig.Dispose();
+        _disposed = true;
+    }
+
+    private void OnRecognizing(object? sender, TranslationRecognitionEventArgs e) => _worker.OnRecognizing(e);
+
+    private void OnRecognized(object? sender, TranslationRecognitionEventArgs e) => _worker.OnRecognized(e);
+
+    private void OnCanceled(object? sender, TranslationRecognitionCanceledEventArgs e)
+    {
+        _worker.OnCanceled(e);
+        Complete();
+    }
+
+    private void OnSpeechStartDetected(object? sender, RecognitionEventArgs e) => _worker.OnSpeechStartDetected(e);
+
+    private void OnSpeechEndDetected(object? sender, RecognitionEventArgs e) => _worker.OnSpeechEndDetected(e);
+
+    private void OnSessionStarted(object? sender, SessionEventArgs e) => _worker.OnSessionStarted(e);
+
+    private void OnSessionStopped(object? sender, SessionEventArgs e)
+    {
+        _worker.OnSessionStopped(e);
+        Complete();
+    }
+
+    private void Complete()
+    {
+        IsRunning = false;
+        _completion.TrySetResult();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+}

--- a/src/Shared/Translator.cs
+++ b/src/Shared/Translator.cs
@@ -32,7 +32,7 @@ public class Translator
         _speechTranslationConfig.SetProperty(PropertyId.SpeechServiceConnection_TranslationVoice, "en-US-JennyNeural");
     }
 
-    public async Task MultiLingualTranslation(TranslationRecognizerWorkerBase worker)
+    public async Task<ITranslationSession> StartTranslationAsync(TranslationRecognizerWorkerBase worker)
     {
         if (worker is null)
         {
@@ -40,38 +40,17 @@ public class Translator
         }
 
         var autoDetectSourceLanguageConfig = AutoDetectSourceLanguageConfig.FromLanguages([_speechTranslationConfig.SpeechRecognitionLanguage]);
-        var stopTranslation = new TaskCompletionSource<int>();
+        var audioInput = AudioConfig.FromDefaultMicrophoneInput();
+        var recognizer = new TranslationRecognizer(_speechTranslationConfig, autoDetectSourceLanguageConfig, audioInput);
+        var session = new TranslationSession(audioInput, recognizer, worker);
 
-        using (var audioInput = AudioConfig.FromDefaultMicrophoneInput())
-        using (var recognizer = new TranslationRecognizer(_speechTranslationConfig, autoDetectSourceLanguageConfig, audioInput))
-        {
-            recognizer.Recognizing += (s, e) => worker.OnRecognizing(e);
+        await session.StartAsync().ConfigureAwait(false);
+        return session;
+    }
 
-            recognizer.Recognized += (s, e) => worker.OnRecognized(e);
-
-            recognizer.Canceled += (s, e) =>
-            {
-                stopTranslation.TrySetResult(0);
-                worker.OnCanceled(e);
-            };
-
-            recognizer.SpeechStartDetected += (s, e) => worker.OnSpeechStartDetected(e);
-
-            recognizer.SpeechEndDetected += (s, e) => worker.OnSpeechEndDetected(e);
-
-            recognizer.SessionStarted += (s, e) => worker.OnSessionStarted(e);
-
-            recognizer.SessionStopped += (s, e) =>
-            {
-                stopTranslation.TrySetResult(0);
-                worker.OnSessionStopped(e);
-            };
-
-            // Starts continuous recognition. Uses StopContinuousRecognitionAsync() to stop recognition.
-            await recognizer.StartContinuousRecognitionAsync().ConfigureAwait(false);
-
-            Task.WaitAny(new[] { stopTranslation.Task });
-            await recognizer.StopContinuousRecognitionAsync().ConfigureAwait(false);
-        }
+    public async Task MultiLingualTranslation(TranslationRecognizerWorkerBase worker)
+    {
+        await using var session = await StartTranslationAsync(worker).ConfigureAwait(false);
+        await session.Completion.ConfigureAwait(false);
     }
 }

--- a/src/SpeechTranslatorConsole/SpeechTranslatorConsole.csproj
+++ b/src/SpeechTranslatorConsole/SpeechTranslatorConsole.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>1.1.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SpeechTranslatorDesktop/App.xaml
+++ b/src/SpeechTranslatorDesktop/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="SpeechTranslatorDesktop.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/src/SpeechTranslatorDesktop/App.xaml.cs
+++ b/src/SpeechTranslatorDesktop/App.xaml.cs
@@ -1,0 +1,5 @@
+namespace SpeechTranslatorDesktop;
+
+public partial class App : Application
+{
+}

--- a/src/SpeechTranslatorDesktop/AssemblyInfo.cs
+++ b/src/SpeechTranslatorDesktop/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SpeechTranslator.Desktop.Tests")]

--- a/src/SpeechTranslatorDesktop/Behaviors/AutoScrollDataGridBehavior.cs
+++ b/src/SpeechTranslatorDesktop/Behaviors/AutoScrollDataGridBehavior.cs
@@ -1,0 +1,64 @@
+﻿namespace SpeechTranslatorDesktop.Behaviors;
+
+/// <summary>
+/// DataGridに新規アイテムが追加された時に自動的に最下部にスクロールするビヘイビア。
+/// </summary>
+public static class AutoScrollDataGridBehavior
+{
+    public static bool GetAutoScroll(DataGrid dataGrid)
+    {
+        ArgumentNullException.ThrowIfNull(dataGrid);
+        return (bool)dataGrid.GetValue(AutoScrollProperty);
+    }
+
+    public static void SetAutoScroll(DataGrid dataGrid, bool value)
+    {
+        ArgumentNullException.ThrowIfNull(dataGrid);
+        dataGrid.SetValue(AutoScrollProperty, value);
+    }
+
+    public static readonly DependencyProperty AutoScrollProperty = DependencyProperty.RegisterAttached(
+        "AutoScroll",
+        typeof(bool),
+        typeof(AutoScrollDataGridBehavior),
+        new PropertyMetadata(false, OnAutoScrollPropertyChanged));
+
+    private static void OnAutoScrollPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not DataGrid dataGrid)
+        {
+            return;
+        }
+
+        if ((bool)e.NewValue)
+        {
+            dataGrid.ItemContainerGenerator.ItemsChanged += (s, args) => ScrollToBottom(dataGrid);
+
+            // ItemsSource が後から設定される場合に対応
+            var descriptor = DependencyPropertyDescriptor.FromProperty(ItemsControl.ItemsSourceProperty, typeof(DataGrid));
+            descriptor?.AddValueChanged(dataGrid, (s, args) =>
+            {
+                if (dataGrid.ItemsSource is INotifyCollectionChanged observable)
+                {
+                    observable.CollectionChanged += (sender, collectionArgs) => ScrollToBottom(dataGrid);
+                }
+            });
+        }
+    }
+
+    private static void ScrollToBottom(DataGrid dataGrid)
+    {
+        if (dataGrid.Items.Count == 0)
+        {
+            return;
+        }
+
+        dataGrid.Dispatcher.BeginInvoke(
+            System.Windows.Threading.DispatcherPriority.Render,
+            () =>
+            {
+                var lastIndex = dataGrid.Items.Count - 1;
+                dataGrid.ScrollIntoView(dataGrid.Items[lastIndex]);
+            });
+    }
+}

--- a/src/SpeechTranslatorDesktop/Behaviors/AutoScrollListBoxBehavior.cs
+++ b/src/SpeechTranslatorDesktop/Behaviors/AutoScrollListBoxBehavior.cs
@@ -1,0 +1,64 @@
+﻿namespace SpeechTranslatorDesktop.Behaviors;
+
+/// <summary>
+/// ListBoxに新規アイテムが追加された時に自動的に最下部にスクロールするビヘイビア。
+/// </summary>
+public static class AutoScrollListBoxBehavior
+{
+    public static bool GetAutoScroll(ListBox listBox)
+    {
+        ArgumentNullException.ThrowIfNull(listBox);
+        return (bool)listBox.GetValue(AutoScrollProperty);
+    }
+
+    public static void SetAutoScroll(ListBox listBox, bool value)
+    {
+        ArgumentNullException.ThrowIfNull(listBox);
+        listBox.SetValue(AutoScrollProperty, value);
+    }
+
+    public static readonly DependencyProperty AutoScrollProperty = DependencyProperty.RegisterAttached(
+        "AutoScroll",
+        typeof(bool),
+        typeof(AutoScrollListBoxBehavior),
+        new PropertyMetadata(false, OnAutoScrollPropertyChanged));
+
+    private static void OnAutoScrollPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not ListBox listBox)
+        {
+            return;
+        }
+
+        if ((bool)e.NewValue)
+        {
+            listBox.ItemContainerGenerator.ItemsChanged += (s, args) => ScrollToBottom(listBox);
+
+            // ItemsSource が後から設定される場合に対応
+            var descriptor = DependencyPropertyDescriptor.FromProperty(ItemsControl.ItemsSourceProperty, typeof(ListBox));
+            descriptor?.AddValueChanged(listBox, (s, args) =>
+            {
+                if (listBox.ItemsSource is INotifyCollectionChanged observable)
+                {
+                    observable.CollectionChanged += (sender, collectionArgs) => ScrollToBottom(listBox);
+                }
+            });
+        }
+    }
+
+    private static void ScrollToBottom(ListBox listBox)
+    {
+        if (listBox.Items.Count == 0)
+        {
+            return;
+        }
+
+        listBox.Dispatcher.BeginInvoke(
+            System.Windows.Threading.DispatcherPriority.Render,
+            () =>
+            {
+                var lastIndex = listBox.Items.Count - 1;
+                listBox.ScrollIntoView(listBox.Items[lastIndex]);
+            });
+    }
+}

--- a/src/SpeechTranslatorDesktop/Commands/AsyncRelayCommand.cs
+++ b/src/SpeechTranslatorDesktop/Commands/AsyncRelayCommand.cs
@@ -1,0 +1,77 @@
+using System.Windows.Input;
+using SpeechTranslatorDesktop.Services;
+
+namespace SpeechTranslatorDesktop.Commands;
+
+public sealed class AsyncRelayCommand : ICommand
+{
+    private readonly Func<Task> _execute;
+    private readonly Func<bool>? _canExecute;
+    private readonly IUiDispatcher? _dispatcher;
+    private readonly Action<Exception>? _onException;
+    private bool _isExecuting;
+
+    public AsyncRelayCommand(
+        Func<Task> execute,
+        Func<bool>? canExecute = null,
+        IUiDispatcher? dispatcher = null,
+        Action<Exception>? onException = null)
+    {
+        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        _canExecute = canExecute;
+        _dispatcher = dispatcher;
+        _onException = onException;
+    }
+
+    public event EventHandler? CanExecuteChanged;
+
+    public bool CanExecute(object? parameter) => !_isExecuting && (_canExecute?.Invoke() ?? true);
+
+    public async void Execute(object? parameter)
+    {
+        try
+        {
+            await ExecuteAsync(parameter);
+        }
+        catch (Exception ex)
+        {
+            if (_onException is null)
+            {
+                throw;
+            }
+
+            _onException(ex);
+        }
+    }
+
+    public async Task ExecuteAsync(object? parameter)
+    {
+        if (!CanExecute(parameter))
+        {
+            return;
+        }
+
+        try
+        {
+            _isExecuting = true;
+            RaiseCanExecuteChanged();
+            await _execute();
+        }
+        finally
+        {
+            _isExecuting = false;
+            RaiseCanExecuteChanged();
+        }
+    }
+
+    public void RaiseCanExecuteChanged()
+    {
+        if (_dispatcher is null)
+        {
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+            return;
+        }
+
+        _dispatcher.Invoke(() => CanExecuteChanged?.Invoke(this, EventArgs.Empty));
+    }
+}

--- a/src/SpeechTranslatorDesktop/Commands/RelayCommand.cs
+++ b/src/SpeechTranslatorDesktop/Commands/RelayCommand.cs
@@ -1,0 +1,23 @@
+using System.Windows.Input;
+
+namespace SpeechTranslatorDesktop.Commands;
+
+public sealed class RelayCommand : ICommand
+{
+    private readonly Action _execute;
+    private readonly Func<bool>? _canExecute;
+
+    public RelayCommand(Action execute, Func<bool>? canExecute = null)
+    {
+        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        _canExecute = canExecute;
+    }
+
+    public event EventHandler? CanExecuteChanged;
+
+    public bool CanExecute(object? parameter) => _canExecute?.Invoke() ?? true;
+
+    public void Execute(object? parameter) => _execute();
+
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/src/SpeechTranslatorDesktop/GlobalUsings.cs
+++ b/src/SpeechTranslatorDesktop/GlobalUsings.cs
@@ -1,7 +1,11 @@
-global using System.Collections.ObjectModel;
+﻿global using System.Collections.ObjectModel;
+global using System.Collections.Specialized;
 global using System.ComponentModel;
 global using System.IO;
 global using System.Runtime.CompilerServices;
 global using System.Windows;
+global using System.Windows.Controls;
+global using System.Windows.Controls.Primitives;
+global using System.ComponentModel.Design;
 global using Microsoft.CognitiveServices.Speech;
 global using Microsoft.CognitiveServices.Speech.Translation;

--- a/src/SpeechTranslatorDesktop/GlobalUsings.cs
+++ b/src/SpeechTranslatorDesktop/GlobalUsings.cs
@@ -1,0 +1,7 @@
+global using System.Collections.ObjectModel;
+global using System.ComponentModel;
+global using System.IO;
+global using System.Runtime.CompilerServices;
+global using System.Windows;
+global using Microsoft.CognitiveServices.Speech;
+global using Microsoft.CognitiveServices.Speech.Translation;

--- a/src/SpeechTranslatorDesktop/MainWindow.xaml
+++ b/src/SpeechTranslatorDesktop/MainWindow.xaml
@@ -1,0 +1,90 @@
+<Window x:Class="SpeechTranslatorDesktop.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Speech Translator Desktop"
+        Height="640"
+        Width="960"
+        MinHeight="480"
+        MinWidth="720">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <StackPanel Grid.Row="0"
+                    Grid.Column="0"
+                    Margin="0,0,12,12">
+            <TextBlock FontWeight="Bold" Text="話者言語" />
+            <ComboBox ItemsSource="{Binding AvailableLanguages}"
+                      SelectedItem="{Binding SelectedSourceLanguage}"
+                      Margin="0,6,0,0" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="0"
+                    Grid.Column="1"
+                    Margin="12,0,0,12">
+            <TextBlock FontWeight="Bold" Text="翻訳先言語" />
+            <ComboBox ItemsSource="{Binding AvailableLanguages}"
+                      SelectedItem="{Binding SelectedTargetLanguage}"
+                      Margin="0,6,0,0" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="1"
+                    Grid.ColumnSpan="2"
+                    Margin="0,0,0,12">
+            <TextBlock FontWeight="Bold" Text="記録ファイル名（任意）" />
+            <TextBox Margin="0,6,0,0"
+                     Text="{Binding RecordingFileName, UpdateSourceTrigger=PropertyChanged}" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="2"
+                    Grid.ColumnSpan="2"
+                    Orientation="Horizontal"
+                    Margin="0,0,0,12">
+            <Button Width="120"
+                    Command="{Binding StartCommand}"
+                    Content="開始" />
+            <Button Width="120"
+                    Margin="12,0,0,0"
+                    Command="{Binding StopCommand}"
+                    Content="停止" />
+            <TextBlock Margin="24,4,0,0"
+                       VerticalAlignment="Center"
+                       FontWeight="Bold"
+                       Text="{Binding StatusMessage}" />
+        </StackPanel>
+
+        <GroupBox Grid.Row="3"
+                  Grid.ColumnSpan="2"
+                  Header="翻訳ログ"
+                  Margin="0,0,0,12">
+            <DataGrid ItemsSource="{Binding TranslationLogs}"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True"
+                      HeadersVisibility="Column">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="原文"
+                                        Binding="{Binding SourceText}"
+                                        Width="*" />
+                    <DataGridTextColumn Header="翻訳文"
+                                        Binding="{Binding TranslatedText}"
+                                        Width="*" />
+                </DataGrid.Columns>
+            </DataGrid>
+        </GroupBox>
+
+        <GroupBox Grid.Row="4"
+                  Grid.ColumnSpan="2"
+                  Header="状態ログ">
+            <ListBox ItemsSource="{Binding ActivityLogs}" />
+        </GroupBox>
+    </Grid>
+</Window>

--- a/src/SpeechTranslatorDesktop/MainWindow.xaml
+++ b/src/SpeechTranslatorDesktop/MainWindow.xaml
@@ -1,6 +1,7 @@
-<Window x:Class="SpeechTranslatorDesktop.MainWindow"
+﻿<Window x:Class="SpeechTranslatorDesktop.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:SpeechTranslatorDesktop.Behaviors"
         Title="Speech Translator Desktop"
         Height="640"
         Width="960"
@@ -69,7 +70,8 @@
             <DataGrid ItemsSource="{Binding TranslationLogs}"
                       AutoGenerateColumns="False"
                       IsReadOnly="True"
-                      HeadersVisibility="Column">
+                      HeadersVisibility="Column"
+                      local:AutoScrollDataGridBehavior.AutoScroll="True">
                 <DataGrid.Columns>
                     <DataGridTextColumn Header="原文"
                                         Binding="{Binding SourceText}"
@@ -84,7 +86,8 @@
         <GroupBox Grid.Row="4"
                   Grid.ColumnSpan="2"
                   Header="状態ログ">
-            <ListBox ItemsSource="{Binding ActivityLogs}" />
+            <ListBox ItemsSource="{Binding ActivityLogs}"
+                     local:AutoScrollListBoxBehavior.AutoScroll="True" />
         </GroupBox>
     </Grid>
 </Window>

--- a/src/SpeechTranslatorDesktop/MainWindow.xaml.cs
+++ b/src/SpeechTranslatorDesktop/MainWindow.xaml.cs
@@ -1,0 +1,19 @@
+using SpeechTranslatorDesktop.Services;
+using SpeechTranslatorDesktop.ViewModels;
+
+namespace SpeechTranslatorDesktop;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+        var recordingFileService = new RecordingFileService(AppContext.BaseDirectory);
+        DataContext = new MainViewModel(
+            new WpfUiDispatcher(),
+            new EnvironmentSpeechCredentialsProvider(),
+            recordingFileService,
+            new DesktopTranslationController(),
+            new DesktopTranslationWorkerFactory(recordingFileService));
+    }
+}

--- a/src/SpeechTranslatorDesktop/Models/LanguageOption.cs
+++ b/src/SpeechTranslatorDesktop/Models/LanguageOption.cs
@@ -1,0 +1,6 @@
+namespace SpeechTranslatorDesktop.Models;
+
+public sealed record LanguageOption(string Code, string DisplayName)
+{
+    public override string ToString() => DisplayName;
+}

--- a/src/SpeechTranslatorDesktop/Models/TranslationLogItem.cs
+++ b/src/SpeechTranslatorDesktop/Models/TranslationLogItem.cs
@@ -1,0 +1,3 @@
+namespace SpeechTranslatorDesktop.Models;
+
+public sealed record TranslationLogItem(string SourceText, string TranslatedText);

--- a/src/SpeechTranslatorDesktop/Services/DesktopTranslationController.cs
+++ b/src/SpeechTranslatorDesktop/Services/DesktopTranslationController.cs
@@ -1,0 +1,144 @@
+using SpeechTranslatorShared;
+
+namespace SpeechTranslatorDesktop.Services;
+
+public sealed class DesktopTranslationController : ITranslationController
+{
+    private readonly object _syncRoot = new();
+    private readonly Func<SpeechCredentials, string, string, TranslationRecognizerWorkerBase, CancellationToken, Task<ITranslationSession>> _startSessionAsync;
+    private ITranslationSession? _session;
+    private ITranslationSession? _sessionBeingStopped;
+
+    public DesktopTranslationController()
+        : this(StartSessionAsync)
+    {
+    }
+
+    internal DesktopTranslationController(Func<SpeechCredentials, string, string, TranslationRecognizerWorkerBase, CancellationToken, Task<ITranslationSession>> startSessionAsync)
+    {
+        _startSessionAsync = startSessionAsync ?? throw new ArgumentNullException(nameof(startSessionAsync));
+    }
+
+    public bool IsRunning
+    {
+        get
+        {
+            lock (_syncRoot)
+            {
+                return _session is not null;
+            }
+        }
+    }
+
+    public async Task StartAsync(SpeechCredentials credentials, string sourceLanguage, string targetLanguage, TranslationRecognizerWorkerBase worker, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(credentials);
+        ArgumentNullException.ThrowIfNull(worker);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceLanguage);
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetLanguage);
+
+        lock (_syncRoot)
+        {
+            if (_session is not null)
+            {
+                throw new InvalidOperationException("Translation is already running.");
+            }
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var session = await _startSessionAsync(credentials, sourceLanguage, targetLanguage, worker, cancellationToken).ConfigureAwait(false);
+
+        lock (_syncRoot)
+        {
+            _session = session;
+        }
+
+        _ = ObserveCompletionAsync(session);
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        ITranslationSession? session;
+        lock (_syncRoot)
+        {
+            session = _session;
+
+            if (session is not null)
+            {
+                _sessionBeingStopped = session;
+            }
+        }
+
+        if (session is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await session.StopAsync().ConfigureAwait(false);
+            await session.DisposeAsync().ConfigureAwait(false);
+
+            lock (_syncRoot)
+            {
+                if (ReferenceEquals(_session, session))
+                {
+                    _session = null;
+                }
+
+                if (ReferenceEquals(_sessionBeingStopped, session))
+                {
+                    _sessionBeingStopped = null;
+                }
+            }
+        }
+        catch
+        {
+            lock (_syncRoot)
+            {
+                if (ReferenceEquals(_sessionBeingStopped, session))
+                {
+                    _sessionBeingStopped = null;
+                }
+            }
+
+            throw;
+        }
+    }
+
+    private async Task ObserveCompletionAsync(ITranslationSession session)
+    {
+        try
+        {
+            await session.Completion.ConfigureAwait(false);
+        }
+        finally
+        {
+            var shouldDispose = false;
+            lock (_syncRoot)
+            {
+                if (ReferenceEquals(_session, session) && !ReferenceEquals(_sessionBeingStopped, session))
+                {
+                    _session = null;
+                    shouldDispose = true;
+                }
+            }
+
+            if (shouldDispose)
+            {
+                await session.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static Task<ITranslationSession> StartSessionAsync(SpeechCredentials credentials, string sourceLanguage, string targetLanguage, TranslationRecognizerWorkerBase worker, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var endpointUrl = new Uri($"wss://{credentials.Region}.stt.speech.microsoft.com/speech/universal/v2");
+        var translator = new Translator(endpointUrl, credentials.Key, sourceLanguage, targetLanguage);
+        return translator.StartTranslationAsync(worker);
+    }
+}

--- a/src/SpeechTranslatorDesktop/Services/DesktopTranslationStatus.cs
+++ b/src/SpeechTranslatorDesktop/Services/DesktopTranslationStatus.cs
@@ -1,0 +1,16 @@
+namespace SpeechTranslatorDesktop.Services;
+
+public enum DesktopTranslationStatus
+{
+    Started,
+    Recognizing,
+    RecognizedSpeech,
+    TranslatedSpeech,
+    Error,
+    NoMatch,
+    Canceled,
+    SpeechStartDetected,
+    SpeechEndDetected,
+    SessionStarted,
+    SessionStopped
+}

--- a/src/SpeechTranslatorDesktop/Services/DesktopTranslationWorker.cs
+++ b/src/SpeechTranslatorDesktop/Services/DesktopTranslationWorker.cs
@@ -1,0 +1,116 @@
+using SpeechTranslatorDesktop.Models;
+using SpeechTranslatorShared;
+
+namespace SpeechTranslatorDesktop.Services;
+
+public sealed class DesktopTranslationWorker : TranslationRecognizerWorkerBase, IDesktopTranslationWorker
+{
+    private readonly string _targetLanguage;
+    private readonly string? _recordingFileName;
+    private readonly IRecordingFileService _recordingFileService;
+
+    public DesktopTranslationWorker(string targetLanguage, string? recordingFileName, IRecordingFileService recordingFileService)
+    {
+        if (string.IsNullOrWhiteSpace(targetLanguage))
+        {
+            throw new ArgumentException($"'{nameof(targetLanguage)}' を NULL または空にすることはできません。", nameof(targetLanguage));
+        }
+
+        _targetLanguage = targetLanguage;
+        _recordingFileName = recordingFileName;
+        _recordingFileService = recordingFileService ?? throw new ArgumentNullException(nameof(recordingFileService));
+    }
+
+    public TranslationRecognizerWorkerBase RecognizerWorker => this;
+
+    public event EventHandler<string>? MessageLogged;
+
+    public event EventHandler<WorkerStatusChangedEventArgs>? StatusChanged;
+
+    public event EventHandler<TranslationLogItem>? TranslationLogged;
+
+    public override void OnRecognizing(TranslationRecognitionEventArgs e)
+    {
+        RaiseStatusChanged(DesktopTranslationStatus.Recognizing, "認識中");
+    }
+
+    public override void OnRecognized(TranslationRecognitionEventArgs e)
+    {
+        var result = e.Result;
+
+        if (result.Reason == ResultReason.TranslatedSpeech)
+        {
+            var translatedText = result.Translations.TryGetValue(_targetLanguage, out var value)
+                ? value
+                : result.Translations.Values.FirstOrDefault() ?? string.Empty;
+            HandleTranslatedSpeech(result.Text, translatedText);
+            return;
+        }
+
+        if (result.Reason == ResultReason.RecognizedSpeech)
+        {
+            RaiseStatusChanged(DesktopTranslationStatus.RecognizedSpeech, "認識のみ");
+            MessageLogged?.Invoke(this, $"認識のみ: {result.Text}");
+            return;
+        }
+
+        if (result.Reason == ResultReason.NoMatch)
+        {
+            RaiseStatusChanged(DesktopTranslationStatus.NoMatch, "NoMatch");
+            MessageLogged?.Invoke(this, "NOMATCH: Speech could not be recognized.");
+        }
+    }
+
+    public override void OnCanceled(TranslationRecognitionCanceledEventArgs e)
+    {
+        var message = e.Reason == CancellationReason.Error
+            ? $"Cancel/Error: {e.ErrorDetails}"
+            : $"Canceled: {e.Reason}";
+
+        RaiseStatusChanged(DesktopTranslationStatus.Canceled, "Cancel/Error");
+        MessageLogged?.Invoke(this, message);
+    }
+
+    public override void OnSpeechStartDetected(RecognitionEventArgs e)
+    {
+        RaiseStatusChanged(DesktopTranslationStatus.SpeechStartDetected, "音声開始を検出");
+    }
+
+    public override void OnSpeechEndDetected(RecognitionEventArgs e)
+    {
+        RaiseStatusChanged(DesktopTranslationStatus.SpeechEndDetected, "音声終了を検出");
+    }
+
+    public override void OnSessionStarted(SessionEventArgs e)
+    {
+        RaiseStatusChanged(DesktopTranslationStatus.SessionStarted, "セッション開始");
+    }
+
+    public override void OnSessionStopped(SessionEventArgs e)
+    {
+        RaiseStatusChanged(DesktopTranslationStatus.SessionStopped, "セッション停止");
+    }
+
+    internal void HandleTranslatedSpeech(string sourceText, string translatedText)
+    {
+        var translation = new TranslationLogItem(sourceText, translatedText);
+        TranslationLogged?.Invoke(this, translation);
+        MessageLogged?.Invoke(this, $"原文: {translation.SourceText}");
+        MessageLogged?.Invoke(this, $"翻訳: {translation.TranslatedText}");
+
+        try
+        {
+            _recordingFileService.AppendTranslation(_recordingFileName, translation.SourceText, translation.TranslatedText);
+            RaiseStatusChanged(DesktopTranslationStatus.TranslatedSpeech, "翻訳成功");
+        }
+        catch (Exception ex)
+        {
+            RaiseStatusChanged(DesktopTranslationStatus.Error, $"記録ファイルの保存に失敗しました: {ex.Message}");
+        }
+    }
+
+    private void RaiseStatusChanged(DesktopTranslationStatus status, string message)
+    {
+        StatusChanged?.Invoke(this, new WorkerStatusChangedEventArgs(status, message));
+    }
+}

--- a/src/SpeechTranslatorDesktop/Services/DesktopTranslationWorkerFactory.cs
+++ b/src/SpeechTranslatorDesktop/Services/DesktopTranslationWorkerFactory.cs
@@ -1,0 +1,16 @@
+namespace SpeechTranslatorDesktop.Services;
+
+public sealed class DesktopTranslationWorkerFactory : IDesktopTranslationWorkerFactory
+{
+    private readonly IRecordingFileService _recordingFileService;
+
+    public DesktopTranslationWorkerFactory(IRecordingFileService recordingFileService)
+    {
+        _recordingFileService = recordingFileService ?? throw new ArgumentNullException(nameof(recordingFileService));
+    }
+
+    public IDesktopTranslationWorker Create(string targetLanguage, string? recordingFileName)
+    {
+        return new DesktopTranslationWorker(targetLanguage, recordingFileName, _recordingFileService);
+    }
+}

--- a/src/SpeechTranslatorDesktop/Services/EnvironmentSpeechCredentialsProvider.cs
+++ b/src/SpeechTranslatorDesktop/Services/EnvironmentSpeechCredentialsProvider.cs
@@ -1,0 +1,35 @@
+namespace SpeechTranslatorDesktop.Services;
+
+public sealed class EnvironmentSpeechCredentialsProvider : ISpeechCredentialsProvider
+{
+    private readonly Func<string, string?> _environmentReader;
+
+    public EnvironmentSpeechCredentialsProvider(Func<string, string?>? environmentReader = null)
+    {
+        _environmentReader = environmentReader ?? Environment.GetEnvironmentVariable;
+    }
+
+    public SpeechCredentialsResult GetCredentials()
+    {
+        var region = _environmentReader("SPEECH_REGION");
+        var key = _environmentReader("SPEECH_KEY");
+        var missingVariables = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(region))
+        {
+            missingVariables.Add("SPEECH_REGION");
+        }
+
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            missingVariables.Add("SPEECH_KEY");
+        }
+
+        if (missingVariables.Count > 0)
+        {
+            return SpeechCredentialsResult.Failure($"Required environment variables are missing: {string.Join(", ", missingVariables)}");
+        }
+
+        return SpeechCredentialsResult.Success(new SpeechCredentials(region!, key!));
+    }
+}

--- a/src/SpeechTranslatorDesktop/Services/IDesktopTranslationWorker.cs
+++ b/src/SpeechTranslatorDesktop/Services/IDesktopTranslationWorker.cs
@@ -1,0 +1,15 @@
+using SpeechTranslatorDesktop.Models;
+using SpeechTranslatorShared;
+
+namespace SpeechTranslatorDesktop.Services;
+
+public interface IDesktopTranslationWorker
+{
+    TranslationRecognizerWorkerBase RecognizerWorker { get; }
+
+    event EventHandler<string>? MessageLogged;
+
+    event EventHandler<WorkerStatusChangedEventArgs>? StatusChanged;
+
+    event EventHandler<TranslationLogItem>? TranslationLogged;
+}

--- a/src/SpeechTranslatorDesktop/Services/IDesktopTranslationWorkerFactory.cs
+++ b/src/SpeechTranslatorDesktop/Services/IDesktopTranslationWorkerFactory.cs
@@ -1,0 +1,6 @@
+namespace SpeechTranslatorDesktop.Services;
+
+public interface IDesktopTranslationWorkerFactory
+{
+    IDesktopTranslationWorker Create(string targetLanguage, string? recordingFileName);
+}

--- a/src/SpeechTranslatorDesktop/Services/IRecordingFileService.cs
+++ b/src/SpeechTranslatorDesktop/Services/IRecordingFileService.cs
@@ -1,0 +1,8 @@
+namespace SpeechTranslatorDesktop.Services;
+
+public interface IRecordingFileService
+{
+    string? NormalizeFileName(string? fileName);
+
+    void AppendTranslation(string? fileName, string sourceText, string translatedText);
+}

--- a/src/SpeechTranslatorDesktop/Services/ISpeechCredentialsProvider.cs
+++ b/src/SpeechTranslatorDesktop/Services/ISpeechCredentialsProvider.cs
@@ -1,0 +1,6 @@
+namespace SpeechTranslatorDesktop.Services;
+
+public interface ISpeechCredentialsProvider
+{
+    SpeechCredentialsResult GetCredentials();
+}

--- a/src/SpeechTranslatorDesktop/Services/ITranslationController.cs
+++ b/src/SpeechTranslatorDesktop/Services/ITranslationController.cs
@@ -1,0 +1,12 @@
+using SpeechTranslatorShared;
+
+namespace SpeechTranslatorDesktop.Services;
+
+public interface ITranslationController
+{
+    bool IsRunning { get; }
+
+    Task StartAsync(SpeechCredentials credentials, string sourceLanguage, string targetLanguage, TranslationRecognizerWorkerBase worker, CancellationToken cancellationToken = default);
+
+    Task StopAsync(CancellationToken cancellationToken = default);
+}

--- a/src/SpeechTranslatorDesktop/Services/IUiDispatcher.cs
+++ b/src/SpeechTranslatorDesktop/Services/IUiDispatcher.cs
@@ -1,0 +1,6 @@
+namespace SpeechTranslatorDesktop.Services;
+
+public interface IUiDispatcher
+{
+    void Invoke(Action action);
+}

--- a/src/SpeechTranslatorDesktop/Services/RecordingFileService.cs
+++ b/src/SpeechTranslatorDesktop/Services/RecordingFileService.cs
@@ -1,0 +1,118 @@
+using System.Text;
+
+namespace SpeechTranslatorDesktop.Services;
+
+public sealed class RecordingFileService : IRecordingFileService
+{
+    private static readonly HashSet<string> ReservedFileNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "CON", "PRN", "AUX", "NUL",
+        "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+        "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+    };
+
+    private readonly string _rootDirectory;
+
+    public RecordingFileService(string rootDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(rootDirectory))
+        {
+            throw new ArgumentException($"'{nameof(rootDirectory)}' を NULL または空にすることはできません。", nameof(rootDirectory));
+        }
+
+        _rootDirectory = rootDirectory;
+    }
+
+    public void AppendTranslation(string? fileName, string sourceText, string translatedText)
+    {
+        var safeFileName = NormalizeFileName(fileName);
+        if (safeFileName is null)
+        {
+            return;
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceText);
+        ArgumentException.ThrowIfNullOrWhiteSpace(translatedText);
+
+        var recordingsDirectory = Path.Combine(_rootDirectory, "recordings");
+        var filePath = GetRecordingFilePath(recordingsDirectory, safeFileName);
+        Directory.CreateDirectory(recordingsDirectory);
+
+        using var streamWriter = new StreamWriter(filePath, append: true, Encoding.UTF8);
+        streamWriter.WriteLine(sourceText);
+        streamWriter.WriteLine(translatedText);
+        streamWriter.WriteLine();
+    }
+
+    public string? NormalizeFileName(string? fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return null;
+        }
+
+        return ValidateFileName(fileName);
+    }
+
+    private static string GetRecordingFilePath(string recordingsDirectory, string fileName)
+    {
+        var recordingsRootPath = Path.GetFullPath(recordingsDirectory);
+        var filePath = Path.GetFullPath(Path.Combine(recordingsRootPath, $"{fileName}.txt"));
+        var recordingsRootWithSeparator = recordingsRootPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+
+        if (!filePath.StartsWith(recordingsRootWithSeparator, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException("recordings 配下に保存できる単純なファイル名を指定してください。", nameof(fileName));
+        }
+
+        return filePath;
+    }
+
+    private static string ValidateFileName(string fileName)
+    {
+        var trimmedFileName = fileName.Trim();
+
+        if (Path.IsPathRooted(trimmedFileName))
+        {
+            throw new ArgumentException("絶対パスは指定できません。", nameof(fileName));
+        }
+
+        if (trimmedFileName.Contains(Path.DirectorySeparatorChar) || trimmedFileName.Contains(Path.AltDirectorySeparatorChar))
+        {
+            throw new ArgumentException("ディレクトリ区切り文字は指定できません。", nameof(fileName));
+        }
+
+        if (trimmedFileName is "." or ".." || trimmedFileName.Contains("..", StringComparison.Ordinal))
+        {
+            throw new ArgumentException("親ディレクトリ参照は指定できません。", nameof(fileName));
+        }
+
+        if (trimmedFileName.Contains('.', StringComparison.Ordinal))
+        {
+            throw new ArgumentException("拡張子を含まない単純なファイル名を指定してください。", nameof(fileName));
+        }
+
+        if (trimmedFileName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            throw new ArgumentException("無効なファイル名です。", nameof(fileName));
+        }
+
+        if (!trimmedFileName.All(c => char.IsAsciiLetterOrDigit(c) || c is '-' or '_'))
+        {
+            throw new ArgumentException("ファイル名には英数字、ハイフン、アンダースコアのみ使用できます。", nameof(fileName));
+        }
+
+        if (ReservedFileNames.Contains(trimmedFileName))
+        {
+            throw new ArgumentException("予約済みのファイル名は指定できません。", nameof(fileName));
+        }
+
+        if (trimmedFileName.Length == 0)
+        {
+            throw new ArgumentException("ファイル名を指定してください。", nameof(fileName));
+        }
+
+        return trimmedFileName;
+    }
+}

--- a/src/SpeechTranslatorDesktop/Services/SpeechCredentials.cs
+++ b/src/SpeechTranslatorDesktop/Services/SpeechCredentials.cs
@@ -1,0 +1,3 @@
+namespace SpeechTranslatorDesktop.Services;
+
+public sealed record SpeechCredentials(string Region, string Key);

--- a/src/SpeechTranslatorDesktop/Services/SpeechCredentialsResult.cs
+++ b/src/SpeechTranslatorDesktop/Services/SpeechCredentialsResult.cs
@@ -1,0 +1,20 @@
+namespace SpeechTranslatorDesktop.Services;
+
+public sealed record SpeechCredentialsResult(bool IsValid, SpeechCredentials? Credentials, string ErrorMessage)
+{
+    public static SpeechCredentialsResult Success(SpeechCredentials credentials)
+    {
+        ArgumentNullException.ThrowIfNull(credentials);
+        return new SpeechCredentialsResult(true, credentials, string.Empty);
+    }
+
+    public static SpeechCredentialsResult Failure(string errorMessage)
+    {
+        if (string.IsNullOrWhiteSpace(errorMessage))
+        {
+            throw new ArgumentException($"'{nameof(errorMessage)}' を NULL または空にすることはできません。", nameof(errorMessage));
+        }
+
+        return new SpeechCredentialsResult(false, null, errorMessage);
+    }
+}

--- a/src/SpeechTranslatorDesktop/Services/WorkerStatusChangedEventArgs.cs
+++ b/src/SpeechTranslatorDesktop/Services/WorkerStatusChangedEventArgs.cs
@@ -1,0 +1,14 @@
+namespace SpeechTranslatorDesktop.Services;
+
+public sealed class WorkerStatusChangedEventArgs : EventArgs
+{
+    public WorkerStatusChangedEventArgs(DesktopTranslationStatus status, string message)
+    {
+        Status = status;
+        Message = message ?? string.Empty;
+    }
+
+    public DesktopTranslationStatus Status { get; }
+
+    public string Message { get; }
+}

--- a/src/SpeechTranslatorDesktop/Services/WpfUiDispatcher.cs
+++ b/src/SpeechTranslatorDesktop/Services/WpfUiDispatcher.cs
@@ -1,0 +1,10 @@
+namespace SpeechTranslatorDesktop.Services;
+
+public sealed class WpfUiDispatcher : IUiDispatcher
+{
+    public void Invoke(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        Application.Current.Dispatcher.Invoke(action);
+    }
+}

--- a/src/SpeechTranslatorDesktop/SpeechTranslatorDesktop.csproj
+++ b/src/SpeechTranslatorDesktop/SpeechTranslatorDesktop.csproj
@@ -6,7 +6,6 @@
     <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>1.0.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SpeechTranslatorDesktop/SpeechTranslatorDesktop.csproj
+++ b/src/SpeechTranslatorDesktop/SpeechTranslatorDesktop.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <VersionPrefix>1.0.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SpeechTranslatorDesktop/SpeechTranslatorDesktop.csproj
+++ b/src/SpeechTranslatorDesktop/SpeechTranslatorDesktop.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\SpeechTranslatorShared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SpeechTranslatorDesktop/ViewModels/MainViewModel.cs
+++ b/src/SpeechTranslatorDesktop/ViewModels/MainViewModel.cs
@@ -1,0 +1,304 @@
+using SpeechTranslatorDesktop.Commands;
+using SpeechTranslatorDesktop.Models;
+using SpeechTranslatorDesktop.Services;
+
+namespace SpeechTranslatorDesktop.ViewModels;
+
+public sealed class MainViewModel : INotifyPropertyChanged
+{
+    private readonly IUiDispatcher _dispatcher;
+    private readonly ISpeechCredentialsProvider _credentialsProvider;
+    private readonly IRecordingFileService _recordingFileService;
+    private readonly ITranslationController _translationController;
+    private readonly IDesktopTranslationWorkerFactory _workerFactory;
+    private IDesktopTranslationWorker? _currentWorker;
+    private LanguageOption? _selectedSourceLanguage;
+    private LanguageOption? _selectedTargetLanguage;
+    private string _recordingFileName = string.Empty;
+    private string _statusMessage = "停止";
+    private bool _isRunning;
+
+    public MainViewModel(
+        IUiDispatcher dispatcher,
+        ISpeechCredentialsProvider credentialsProvider,
+        IRecordingFileService recordingFileService,
+        ITranslationController translationController,
+        IDesktopTranslationWorkerFactory workerFactory)
+    {
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _credentialsProvider = credentialsProvider ?? throw new ArgumentNullException(nameof(credentialsProvider));
+        _recordingFileService = recordingFileService ?? throw new ArgumentNullException(nameof(recordingFileService));
+        _translationController = translationController ?? throw new ArgumentNullException(nameof(translationController));
+        _workerFactory = workerFactory ?? throw new ArgumentNullException(nameof(workerFactory));
+
+        AvailableLanguages =
+        [
+            new LanguageOption("en-US", "English (en-US)"),
+            new LanguageOption("ja-JP", "Japanese (ja-JP)")
+        ];
+
+        _selectedSourceLanguage = AvailableLanguages[0];
+        _selectedTargetLanguage = AvailableLanguages[1];
+
+        StartCommand = new AsyncRelayCommand(StartAsync, () => !IsRunning, _dispatcher, HandleCommandException);
+        StopCommand = new AsyncRelayCommand(StopAsync, () => IsRunning, _dispatcher, HandleCommandException);
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public ObservableCollection<string> ActivityLogs { get; } = [];
+
+    public ObservableCollection<LanguageOption> AvailableLanguages { get; }
+
+    public bool IsRunning
+    {
+        get => _isRunning;
+        private set
+        {
+            if (_isRunning == value)
+            {
+                return;
+            }
+
+            _isRunning = value;
+            OnPropertyChanged();
+            StartCommand.RaiseCanExecuteChanged();
+            StopCommand.RaiseCanExecuteChanged();
+        }
+    }
+
+    public string RecordingFileName
+    {
+        get => _recordingFileName;
+        set
+        {
+            if (_recordingFileName == value)
+            {
+                return;
+            }
+
+            _recordingFileName = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public LanguageOption? SelectedSourceLanguage
+    {
+        get => _selectedSourceLanguage;
+        set
+        {
+            if (_selectedSourceLanguage == value)
+            {
+                return;
+            }
+
+            _selectedSourceLanguage = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public LanguageOption? SelectedTargetLanguage
+    {
+        get => _selectedTargetLanguage;
+        set
+        {
+            if (_selectedTargetLanguage == value)
+            {
+                return;
+            }
+
+            _selectedTargetLanguage = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public AsyncRelayCommand StartCommand { get; }
+
+    public string StatusMessage
+    {
+        get => _statusMessage;
+        private set
+        {
+            if (_statusMessage == value)
+            {
+                return;
+            }
+
+            _statusMessage = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public AsyncRelayCommand StopCommand { get; }
+
+    public ObservableCollection<TranslationLogItem> TranslationLogs { get; } = [];
+
+    private async Task StartAsync()
+    {
+        if (SelectedSourceLanguage is null || SelectedTargetLanguage is null)
+        {
+            StatusMessage = "言語を選択してください。";
+            return;
+        }
+
+        string? recordingFileName;
+        try
+        {
+            recordingFileName = _recordingFileService.NormalizeFileName(RecordingFileName);
+            RecordingFileName = recordingFileName ?? string.Empty;
+        }
+        catch (ArgumentException ex)
+        {
+            StatusMessage = $"記録ファイル名が不正です: {ex.Message}";
+            AddActivityLog(StatusMessage);
+            return;
+        }
+
+        var credentialsResult = _credentialsProvider.GetCredentials();
+        if (!credentialsResult.IsValid || credentialsResult.Credentials is null)
+        {
+            StatusMessage = credentialsResult.ErrorMessage;
+            AddActivityLog(credentialsResult.ErrorMessage);
+            return;
+        }
+
+        var worker = _workerFactory.Create(SelectedTargetLanguage.Code, recordingFileName);
+        SubscribeWorker(worker);
+
+        try
+        {
+            await _translationController.StartAsync(
+                credentialsResult.Credentials,
+                SelectedSourceLanguage.Code,
+                SelectedTargetLanguage.Code,
+                worker.RecognizerWorker);
+
+            _currentWorker = worker;
+            IsRunning = true;
+            StatusMessage = "開始";
+            AddActivityLog("翻訳を開始しました。");
+        }
+        catch (Exception ex)
+        {
+            UnsubscribeWorker(worker);
+            StatusMessage = ex.Message;
+            AddActivityLog(ex.Message);
+        }
+    }
+
+    private async Task StopAsync()
+    {
+        try
+        {
+            await _translationController.StopAsync();
+            StatusMessage = "停止";
+            AddActivityLog("翻訳を停止しました。");
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"停止に失敗しました: {ex.Message}";
+            AddActivityLog(StatusMessage);
+        }
+        finally
+        {
+            IsRunning = _translationController.IsRunning;
+
+            if (!IsRunning)
+            {
+                DetachCurrentWorker();
+            }
+        }
+    }
+
+    private void SubscribeWorker(IDesktopTranslationWorker worker)
+    {
+        worker.StatusChanged += OnWorkerStatusChanged;
+        worker.MessageLogged += OnWorkerMessageLogged;
+        worker.TranslationLogged += OnWorkerTranslationLogged;
+    }
+
+    private void UnsubscribeWorker(IDesktopTranslationWorker worker)
+    {
+        worker.StatusChanged -= OnWorkerStatusChanged;
+        worker.MessageLogged -= OnWorkerMessageLogged;
+        worker.TranslationLogged -= OnWorkerTranslationLogged;
+    }
+
+    private void OnWorkerStatusChanged(object? sender, WorkerStatusChangedEventArgs e)
+    {
+        _dispatcher.Invoke(() =>
+        {
+            StatusMessage = e.Message;
+            if (e.Status != DesktopTranslationStatus.Recognizing)
+            {
+                AddActivityLog(e.Message);
+            }
+
+            if (e.Status is DesktopTranslationStatus.Canceled or DesktopTranslationStatus.SessionStopped)
+            {
+                IsRunning = false;
+
+                if (sender is IDesktopTranslationWorker worker)
+                {
+                    UnsubscribeWorker(worker);
+
+                    if (ReferenceEquals(_currentWorker, worker))
+                    {
+                        _currentWorker = null;
+                    }
+                }
+            }
+        });
+    }
+
+    private void OnWorkerMessageLogged(object? sender, string e)
+    {
+        _dispatcher.Invoke(() => AddActivityLog(e));
+    }
+
+    private void OnWorkerTranslationLogged(object? sender, TranslationLogItem e)
+    {
+        _dispatcher.Invoke(() => TranslationLogs.Add(e));
+    }
+
+    private void AddActivityLog(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return;
+        }
+
+        ActivityLogs.Add(message);
+    }
+
+    private void DetachCurrentWorker()
+    {
+        if (_currentWorker is null)
+        {
+            return;
+        }
+
+        UnsubscribeWorker(_currentWorker);
+        _currentWorker = null;
+    }
+
+    private void HandleCommandException(Exception ex)
+    {
+        _dispatcher.Invoke(() =>
+        {
+            StatusMessage = ex.Message;
+            AddActivityLog(ex.Message);
+            IsRunning = _translationController.IsRunning;
+
+            if (!IsRunning)
+            {
+                DetachCurrentWorker();
+            }
+        });
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/tests/Shared.Tests/TranslatorTest.cs
+++ b/tests/Shared.Tests/TranslatorTest.cs
@@ -56,12 +56,21 @@ public class TranslatorTest
     }
 
     [Fact]
-    public void MultiLingualTranslation_NullWorker()
+    public async Task MultiLingualTranslation_NullWorker()
     {
         var translator = CreateTranslator();
-        var action = () => translator.MultiLingualTranslation(null);
+        Func<Task> action = () => translator.MultiLingualTranslation(null!);
 
-        action.Should().ThrowAsync<ArgumentNullException>();
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task StartTranslationAsync_NullWorker()
+    {
+        var translator = CreateTranslator();
+        Func<Task> action = () => translator.StartTranslationAsync(null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
     }
 
     private static Translator CreateTranslator()

--- a/tests/SpeechTranslator.Desktop.Tests/AsyncRelayCommandTests.cs
+++ b/tests/SpeechTranslator.Desktop.Tests/AsyncRelayCommandTests.cs
@@ -1,0 +1,32 @@
+using SpeechTranslatorDesktop.Commands;
+using SpeechTranslatorDesktop.Services;
+
+namespace SpeechTranslator.Desktop.Tests;
+
+public class AsyncRelayCommandTests
+{
+    [Fact]
+    public void RaiseCanExecuteChanged_UsesDispatcher()
+    {
+        var dispatcher = new RecordingDispatcher();
+        var command = new AsyncRelayCommand(() => Task.CompletedTask, dispatcher: dispatcher);
+        var raisedCount = 0;
+        command.CanExecuteChanged += (_, _) => raisedCount++;
+
+        command.RaiseCanExecuteChanged();
+
+        dispatcher.InvokeCount.Should().Be(1);
+        raisedCount.Should().Be(1);
+    }
+
+    private sealed class RecordingDispatcher : IUiDispatcher
+    {
+        public int InvokeCount { get; private set; }
+
+        public void Invoke(Action action)
+        {
+            InvokeCount++;
+            action();
+        }
+    }
+}

--- a/tests/SpeechTranslator.Desktop.Tests/DesktopTranslationControllerTests.cs
+++ b/tests/SpeechTranslator.Desktop.Tests/DesktopTranslationControllerTests.cs
@@ -1,0 +1,165 @@
+using SpeechTranslatorDesktop.Services;
+using SpeechTranslatorShared;
+
+namespace SpeechTranslator.Desktop.Tests;
+
+public class DesktopTranslationControllerTests
+{
+    [Fact]
+    public async Task StopAsync_WhenSessionStopFails_KeepsControllerRunning()
+    {
+        var session = new FakeTranslationSession();
+        session.EnqueueStopBehavior(() => throw new InvalidOperationException("stop failed"));
+        session.EnqueueStopBehavior(() =>
+        {
+            session.Complete();
+            return Task.CompletedTask;
+        });
+        var controller = CreateController(session);
+
+        await controller.StartAsync(new SpeechCredentials("japaneast", "test-key"), "en-US", "ja-JP", new NoOpTranslationRecognizerWorker());
+        await FluentActions.Awaiting(() => controller.StopAsync())
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("stop failed");
+
+        controller.IsRunning.Should().BeTrue();
+        session.DisposeCallCount.Should().Be(0);
+
+        await controller.StopAsync();
+
+        controller.IsRunning.Should().BeFalse();
+        session.DisposeCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task StartAsync_AfterStopFailure_ThrowsWhileOriginalSessionIsTracked()
+    {
+        var session = new FakeTranslationSession();
+        session.EnqueueStopBehavior(() => throw new InvalidOperationException("stop failed"));
+        session.EnqueueStopBehavior(() =>
+        {
+            session.Complete();
+            return Task.CompletedTask;
+        });
+        var controller = CreateController(session);
+
+        await controller.StartAsync(new SpeechCredentials("japaneast", "test-key"), "en-US", "ja-JP", new NoOpTranslationRecognizerWorker());
+        await FluentActions.Awaiting(() => controller.StopAsync()).Should().ThrowAsync<InvalidOperationException>();
+
+        await FluentActions.Awaiting(() => controller.StartAsync(new SpeechCredentials("japaneast", "test-key"), "en-US", "ja-JP", new NoOpTranslationRecognizerWorker()))
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("Translation is already running.");
+
+        await controller.StopAsync();
+        controller.IsRunning.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task StopAsync_WhenDisposeFails_KeepsControllerRunningUntilRetrySucceeds()
+    {
+        var session = new FakeTranslationSession();
+        session.EnqueueStopBehavior(() =>
+        {
+            session.Complete();
+            return Task.CompletedTask;
+        });
+        session.EnqueueStopBehavior(() => Task.CompletedTask);
+        session.EnqueueDisposeBehavior(() => ValueTask.FromException(new InvalidOperationException("dispose failed")));
+        session.EnqueueDisposeBehavior(() => ValueTask.CompletedTask);
+        var controller = CreateController(session);
+
+        await controller.StartAsync(new SpeechCredentials("japaneast", "test-key"), "en-US", "ja-JP", new NoOpTranslationRecognizerWorker());
+        await FluentActions.Awaiting(() => controller.StopAsync())
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("dispose failed");
+
+        controller.IsRunning.Should().BeTrue();
+        session.DisposeCallCount.Should().Be(1);
+
+        await controller.StopAsync();
+
+        controller.IsRunning.Should().BeFalse();
+        session.DisposeCallCount.Should().Be(2);
+    }
+
+    private static DesktopTranslationController CreateController(ITranslationSession session)
+    {
+        return new DesktopTranslationController((credentials, sourceLanguage, targetLanguage, worker, cancellationToken) =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(session);
+        });
+    }
+
+    private sealed class FakeTranslationSession : ITranslationSession
+    {
+        private readonly Queue<Func<Task>> _stopBehaviors = new();
+        private readonly Queue<Func<ValueTask>> _disposeBehaviors = new();
+        private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task Completion => _completion.Task;
+
+        public bool IsRunning { get; private set; } = true;
+
+        public int DisposeCallCount { get; private set; }
+
+        public int StopCallCount { get; private set; }
+
+        public void EnqueueDisposeBehavior(Func<ValueTask> behavior) => _disposeBehaviors.Enqueue(behavior);
+
+        public void EnqueueStopBehavior(Func<Task> behavior) => _stopBehaviors.Enqueue(behavior);
+
+        public void Complete()
+        {
+            IsRunning = false;
+            _completion.TrySetResult();
+        }
+
+        public Task StopAsync()
+        {
+            StopCallCount++;
+            return _stopBehaviors.Count > 0 ? _stopBehaviors.Dequeue().Invoke() : Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCallCount++;
+            IsRunning = false;
+            return _disposeBehaviors.Count > 0 ? _disposeBehaviors.Dequeue().Invoke() : ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class NoOpTranslationRecognizerWorker : TranslationRecognizerWorkerBase
+    {
+        public override void OnCanceled(TranslationRecognitionCanceledEventArgs e)
+        {
+        }
+
+        public override void OnRecognized(TranslationRecognitionEventArgs e)
+        {
+        }
+
+        public override void OnRecognizing(TranslationRecognitionEventArgs e)
+        {
+        }
+
+        public override void OnSessionStarted(SessionEventArgs e)
+        {
+        }
+
+        public override void OnSessionStopped(SessionEventArgs e)
+        {
+        }
+
+        public override void OnSpeechEndDetected(RecognitionEventArgs e)
+        {
+        }
+
+        public override void OnSpeechStartDetected(RecognitionEventArgs e)
+        {
+        }
+    }
+}

--- a/tests/SpeechTranslator.Desktop.Tests/DesktopTranslationWorkerTests.cs
+++ b/tests/SpeechTranslator.Desktop.Tests/DesktopTranslationWorkerTests.cs
@@ -1,0 +1,46 @@
+using SpeechTranslatorDesktop.Models;
+using SpeechTranslatorDesktop.Services;
+
+namespace SpeechTranslator.Desktop.Tests;
+
+public class DesktopTranslationWorkerTests
+{
+    [Fact]
+    public void HandleTranslatedSpeech_WhenRecordingWriteFails_RaisesErrorWithoutThrowing()
+    {
+        var recordingFileService = new ThrowingRecordingFileService(new IOException("disk full"));
+        var worker = new DesktopTranslationWorker("ja-JP", "session-01", recordingFileService);
+        var statuses = new List<WorkerStatusChangedEventArgs>();
+        var translations = new List<TranslationLogItem>();
+
+        worker.StatusChanged += (_, e) => statuses.Add(e);
+        worker.TranslationLogged += (_, e) => translations.Add(e);
+
+        var act = () => worker.HandleTranslatedSpeech("hello", "こんにちは");
+
+        act.Should().NotThrow();
+        translations.Should().ContainSingle();
+        statuses.Should().ContainSingle(e =>
+            e.Status == DesktopTranslationStatus.Error &&
+            e.Message.Contains("記録ファイルの保存に失敗しました") &&
+            e.Message.Contains("disk full"));
+        statuses.Should().NotContain(e => e.Status == DesktopTranslationStatus.TranslatedSpeech);
+    }
+
+    private sealed class ThrowingRecordingFileService : IRecordingFileService
+    {
+        private readonly Exception _exception;
+
+        public ThrowingRecordingFileService(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        public string? NormalizeFileName(string? fileName) => fileName;
+
+        public void AppendTranslation(string? fileName, string sourceText, string translatedText)
+        {
+            throw _exception;
+        }
+    }
+}

--- a/tests/SpeechTranslator.Desktop.Tests/EnvironmentSpeechCredentialsProviderTests.cs
+++ b/tests/SpeechTranslator.Desktop.Tests/EnvironmentSpeechCredentialsProviderTests.cs
@@ -1,0 +1,43 @@
+using SpeechTranslatorDesktop.Services;
+
+namespace SpeechTranslator.Desktop.Tests;
+
+public class EnvironmentSpeechCredentialsProviderTests
+{
+    [Fact]
+    public void GetCredentials_BothValuesPresent_ReturnsCredentials()
+    {
+        var provider = new EnvironmentSpeechCredentialsProvider(name => name switch
+        {
+            "SPEECH_REGION" => "japaneast",
+            "SPEECH_KEY" => "test-key",
+            _ => null
+        });
+
+        var result = provider.GetCredentials();
+
+        result.IsValid.Should().BeTrue();
+        result.Credentials.Should().NotBeNull();
+        result.Credentials!.Region.Should().Be("japaneast");
+        result.Credentials.Key.Should().Be("test-key");
+    }
+
+    [Theory]
+    [InlineData(null, "test-key", "SPEECH_REGION")]
+    [InlineData("japaneast", null, "SPEECH_KEY")]
+    [InlineData(null, null, "SPEECH_REGION, SPEECH_KEY")]
+    public void GetCredentials_MissingValues_ReturnsError(string? region, string? key, string expected)
+    {
+        var provider = new EnvironmentSpeechCredentialsProvider(name => name switch
+        {
+            "SPEECH_REGION" => region,
+            "SPEECH_KEY" => key,
+            _ => null
+        });
+
+        var result = provider.GetCredentials();
+
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Contain(expected);
+    }
+}

--- a/tests/SpeechTranslator.Desktop.Tests/GlobalUsings.cs
+++ b/tests/SpeechTranslator.Desktop.Tests/GlobalUsings.cs
@@ -1,0 +1,4 @@
+global using FluentAssertions;
+global using Microsoft.CognitiveServices.Speech;
+global using Microsoft.CognitiveServices.Speech.Translation;
+global using Xunit;

--- a/tests/SpeechTranslator.Desktop.Tests/MainViewModelTests.cs
+++ b/tests/SpeechTranslator.Desktop.Tests/MainViewModelTests.cs
@@ -1,0 +1,509 @@
+using System.Windows.Input;
+using SpeechTranslatorDesktop.Commands;
+using SpeechTranslatorDesktop.Models;
+using SpeechTranslatorDesktop.Services;
+using SpeechTranslatorDesktop.ViewModels;
+using SpeechTranslatorShared;
+
+namespace SpeechTranslator.Desktop.Tests;
+
+public class MainViewModelTests
+{
+    [Fact]
+    public void InitialState_StartEnabled_StopDisabled()
+    {
+        var viewModel = CreateViewModel();
+
+        viewModel.StartCommand.CanExecute(null).Should().BeTrue();
+        viewModel.StopCommand.CanExecute(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Start_WhenCredentialsMissing_ShowsErrorAndDoesNotStart()
+    {
+        var translationController = new FakeTranslationController();
+        var viewModel = CreateViewModel(
+            credentialsProvider: new FakeSpeechCredentialsProvider(SpeechCredentialsResult.Failure("Missing SPEECH_REGION and SPEECH_KEY.")),
+            translationController: translationController);
+
+        await ExecuteAsync(viewModel.StartCommand);
+
+        translationController.StartCallCount.Should().Be(0);
+        viewModel.StatusMessage.Should().Contain("SPEECH_REGION").And.Contain("SPEECH_KEY");
+        viewModel.IsRunning.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Start_WhenCredentialsPresent_StartsTranslation()
+    {
+        var translationController = new FakeTranslationController();
+        var viewModel = CreateViewModel(translationController: translationController);
+
+        await ExecuteAsync(viewModel.StartCommand);
+
+        translationController.StartCallCount.Should().Be(1);
+        viewModel.StatusMessage.Should().Be("開始");
+        viewModel.IsRunning.Should().BeTrue();
+        viewModel.StartCommand.CanExecute(null).Should().BeFalse();
+        viewModel.StopCommand.CanExecute(null).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Start_WhenRecordingFileNameIsInvalid_ShowsErrorAndDoesNotStart()
+    {
+        var translationController = new FakeTranslationController();
+        var workerFactory = new FakeDesktopTranslationWorkerFactory(new FakeDesktopTranslationWorker());
+        var viewModel = CreateViewModel(
+            recordingFileService: new FakeRecordingFileService
+            {
+                NormalizeFileNameException = new ArgumentException("ファイル名には英数字、ハイフン、アンダースコアのみ使用できます。", "fileName")
+            },
+            translationController: translationController,
+            workerFactory: workerFactory);
+        viewModel.RecordingFileName = "bad name";
+
+        await ExecuteAsync(viewModel.StartCommand);
+
+        translationController.StartCallCount.Should().Be(0);
+        workerFactory.CreateCallCount.Should().Be(0);
+        viewModel.IsRunning.Should().BeFalse();
+        viewModel.StatusMessage.Should().StartWith("記録ファイル名が不正です:");
+        viewModel.ActivityLogs.Should().Contain(viewModel.StatusMessage);
+    }
+
+    [Fact]
+    public async Task Stop_CallsTranslationController()
+    {
+        var translationController = new FakeTranslationController();
+        var viewModel = CreateViewModel(translationController: translationController);
+
+        await ExecuteAsync(viewModel.StartCommand);
+        await ExecuteAsync(viewModel.StopCommand);
+
+        translationController.StopCallCount.Should().Be(1);
+        viewModel.StatusMessage.Should().Be("停止");
+        viewModel.IsRunning.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Stop_WhenControllerThrows_ShowsErrorAndKeepsRunning()
+    {
+        var translationController = new FakeTranslationController
+        {
+            StopException = new InvalidOperationException("stop failed"),
+            KeepRunningOnStopFailure = true
+        };
+        var viewModel = CreateViewModel(translationController: translationController);
+
+        await ExecuteAsync(viewModel.StartCommand);
+        await ExecuteAsync(viewModel.StopCommand);
+
+        viewModel.StatusMessage.Should().Be("停止に失敗しました: stop failed");
+        viewModel.ActivityLogs.Should().Contain("停止に失敗しました: stop failed");
+        viewModel.IsRunning.Should().BeTrue();
+        viewModel.StartCommand.CanExecute(null).Should().BeFalse();
+        viewModel.StopCommand.CanExecute(null).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task WorkerTranslationEvent_AddsTranslationLog()
+    {
+        var worker = new FakeDesktopTranslationWorker();
+        var viewModel = CreateViewModel(workerFactory: new FakeDesktopTranslationWorkerFactory(worker));
+
+        await ExecuteAsync(viewModel.StartCommand);
+        worker.RaiseTranslationLogged(new TranslationLogItem("hello", "こんにちは"));
+
+        viewModel.TranslationLogs.Should().ContainSingle();
+        viewModel.TranslationLogs[0].SourceText.Should().Be("hello");
+        viewModel.TranslationLogs[0].TranslatedText.Should().Be("こんにちは");
+    }
+
+    [Fact]
+    public async Task WorkerStatusEvents_UpdateStatusAndLogs()
+    {
+        var worker = new FakeDesktopTranslationWorker();
+        var viewModel = CreateViewModel(workerFactory: new FakeDesktopTranslationWorkerFactory(worker));
+
+        await ExecuteAsync(viewModel.StartCommand);
+        worker.RaiseStatusChanged(DesktopTranslationStatus.NoMatch, "NoMatch");
+        worker.RaiseMessageLogged("Session stopped.");
+        worker.RaiseStatusChanged(DesktopTranslationStatus.SessionStopped, "セッション停止");
+
+        viewModel.StatusMessage.Should().Be("セッション停止");
+        viewModel.ActivityLogs.Should().Contain("Session stopped.");
+        viewModel.IsRunning.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Start_WhenControllerCompletesAsynchronously_RaisesPropertyChangesOnCapturedContext()
+    {
+        await RunOnSynchronizationContextAsync(async uiThreadId =>
+        {
+            var translationController = new FakeTranslationController { StartShouldYield = true };
+            var viewModel = CreateViewModel(
+                dispatcher: new SynchronizationContextDispatcher(SynchronizationContext.Current!),
+                translationController: translationController);
+            var propertyChangedThreadIds = new List<int>();
+            viewModel.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName is nameof(MainViewModel.IsRunning) or nameof(MainViewModel.StatusMessage))
+                {
+                    propertyChangedThreadIds.Add(Environment.CurrentManagedThreadId);
+                }
+            };
+
+            await ExecuteAsync(viewModel.StartCommand);
+
+            propertyChangedThreadIds.Should().NotBeEmpty();
+            propertyChangedThreadIds.Should().OnlyContain(threadId => threadId == uiThreadId);
+        });
+    }
+
+    [Fact]
+    public async Task WorkerTranslationEvent_FromBackgroundThread_UpdatesCollectionOnUiThread()
+    {
+        await RunOnSynchronizationContextAsync(async uiThreadId =>
+        {
+            var worker = new FakeDesktopTranslationWorker();
+            var viewModel = CreateViewModel(
+                dispatcher: new SynchronizationContextDispatcher(SynchronizationContext.Current!),
+                workerFactory: new FakeDesktopTranslationWorkerFactory(worker));
+            int? collectionChangedThreadId = null;
+
+            viewModel.TranslationLogs.CollectionChanged += (_, _) => collectionChangedThreadId = Environment.CurrentManagedThreadId;
+
+            await ExecuteAsync(viewModel.StartCommand);
+            await Task.Run(() => worker.RaiseTranslationLogged(new TranslationLogItem("hello", "こんにちは")));
+
+            collectionChangedThreadId.Should().Be(uiThreadId);
+            viewModel.TranslationLogs.Should().ContainSingle();
+        });
+    }
+
+    private static MainViewModel CreateViewModel(
+        IUiDispatcher? dispatcher = null,
+        ISpeechCredentialsProvider? credentialsProvider = null,
+        IRecordingFileService? recordingFileService = null,
+        ITranslationController? translationController = null,
+        IDesktopTranslationWorkerFactory? workerFactory = null)
+    {
+        return new MainViewModel(
+            dispatcher ?? new ImmediateDispatcher(),
+            credentialsProvider ?? new FakeSpeechCredentialsProvider(SpeechCredentialsResult.Success(new SpeechCredentials("japaneast", "test-key"))),
+            recordingFileService ?? new FakeRecordingFileService(),
+            translationController ?? new FakeTranslationController(),
+            workerFactory ?? new FakeDesktopTranslationWorkerFactory(new FakeDesktopTranslationWorker()));
+    }
+
+    private static Task ExecuteAsync(ICommand command)
+    {
+        return ((AsyncRelayCommand)command).ExecuteAsync(null);
+    }
+
+    private sealed class ImmediateDispatcher : IUiDispatcher
+    {
+        public void Invoke(Action action) => action();
+    }
+
+    private sealed class FakeSpeechCredentialsProvider : ISpeechCredentialsProvider
+    {
+        private readonly SpeechCredentialsResult _result;
+
+        public FakeSpeechCredentialsProvider(SpeechCredentialsResult result)
+        {
+            _result = result;
+        }
+
+        public SpeechCredentialsResult GetCredentials() => _result;
+    }
+
+    private sealed class FakeTranslationController : ITranslationController
+    {
+        public int StartCallCount { get; private set; }
+        public int StopCallCount { get; private set; }
+        public bool IsRunning { get; private set; }
+        public bool StartShouldYield { get; init; }
+        public Exception? StopException { get; init; }
+        public bool KeepRunningOnStopFailure { get; init; }
+
+        public Task StartAsync(SpeechCredentials credentials, string sourceLanguage, string targetLanguage, TranslationRecognizerWorkerBase worker, CancellationToken cancellationToken = default)
+        {
+            return StartAsyncCore();
+
+            async Task StartAsyncCore()
+            {
+                if (StartShouldYield)
+                {
+                    await Task.Yield();
+                }
+
+                StartCallCount++;
+                IsRunning = true;
+            }
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken = default)
+        {
+            return StopAsyncCore();
+
+            Task StopAsyncCore()
+            {
+                StopCallCount++;
+
+                if (StopException is not null)
+                {
+                    if (!KeepRunningOnStopFailure)
+                    {
+                        IsRunning = false;
+                    }
+
+                    throw StopException;
+                }
+
+                IsRunning = false;
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    private sealed class FakeDesktopTranslationWorkerFactory : IDesktopTranslationWorkerFactory
+    {
+        private readonly IDesktopTranslationWorker _worker;
+        public int CreateCallCount { get; private set; }
+
+        public FakeDesktopTranslationWorkerFactory(IDesktopTranslationWorker worker)
+        {
+            _worker = worker;
+        }
+
+        public IDesktopTranslationWorker Create(string targetLanguage, string? recordingFileName)
+        {
+            CreateCallCount++;
+            return _worker;
+        }
+    }
+
+    private sealed class FakeRecordingFileService : IRecordingFileService
+    {
+        public Exception? NormalizeFileNameException { get; init; }
+
+        public string? NormalizeFileName(string? fileName)
+        {
+            if (NormalizeFileNameException is not null)
+            {
+                throw NormalizeFileNameException;
+            }
+
+            return string.IsNullOrWhiteSpace(fileName) ? null : fileName.Trim();
+        }
+
+        public void AppendTranslation(string? fileName, string sourceText, string translatedText)
+        {
+        }
+    }
+
+    private sealed class FakeDesktopTranslationWorker : IDesktopTranslationWorker
+    {
+        public TranslationRecognizerWorkerBase RecognizerWorker { get; } = new NoOpTranslationRecognizerWorker();
+
+        public event EventHandler<string>? MessageLogged;
+
+        public event EventHandler<WorkerStatusChangedEventArgs>? StatusChanged;
+
+        public event EventHandler<TranslationLogItem>? TranslationLogged;
+
+        public void RaiseMessageLogged(string message) => MessageLogged?.Invoke(this, message);
+
+        public void RaiseStatusChanged(DesktopTranslationStatus status, string message) =>
+            StatusChanged?.Invoke(this, new WorkerStatusChangedEventArgs(status, message));
+
+        public void RaiseTranslationLogged(TranslationLogItem item) => TranslationLogged?.Invoke(this, item);
+    }
+
+    private sealed class NoOpTranslationRecognizerWorker : TranslationRecognizerWorkerBase
+    {
+        public override void OnCanceled(TranslationRecognitionCanceledEventArgs e)
+        {
+        }
+
+        public override void OnRecognized(TranslationRecognitionEventArgs e)
+        {
+        }
+
+        public override void OnRecognizing(TranslationRecognitionEventArgs e)
+        {
+        }
+
+        public override void OnSessionStarted(SessionEventArgs e)
+        {
+        }
+
+        public override void OnSessionStopped(SessionEventArgs e)
+        {
+        }
+
+        public override void OnSpeechEndDetected(RecognitionEventArgs e)
+        {
+        }
+
+        public override void OnSpeechStartDetected(RecognitionEventArgs e)
+        {
+        }
+    }
+
+    private sealed class SynchronizationContextDispatcher : IUiDispatcher
+    {
+        private readonly SynchronizationContext _synchronizationContext;
+
+        public SynchronizationContextDispatcher(SynchronizationContext synchronizationContext)
+        {
+            _synchronizationContext = synchronizationContext;
+        }
+
+        public void Invoke(Action action)
+        {
+            if (SynchronizationContext.Current == _synchronizationContext)
+            {
+                action();
+                return;
+            }
+
+            _synchronizationContext.Send(_ => action(), null);
+        }
+    }
+
+    private static Task RunOnSynchronizationContextAsync(Func<int, Task> testAction)
+    {
+        var completionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() =>
+        {
+            Exception? exception = null;
+            var synchronizationContext = new PumpingSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(synchronizationContext);
+
+            try
+            {
+                var task = testAction(Environment.CurrentManagedThreadId);
+                task.ContinueWith(
+                    completedTask =>
+                    {
+                        exception = completedTask.Exception?.GetBaseException();
+                        synchronizationContext.Complete();
+                    },
+                    CancellationToken.None,
+                    TaskContinuationOptions.None,
+                    TaskScheduler.Default);
+                synchronizationContext.RunOnCurrentThread();
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(null);
+            }
+
+            if (exception is not null)
+            {
+                completionSource.SetException(exception);
+                return;
+            }
+
+            completionSource.SetResult();
+        });
+
+        thread.IsBackground = true;
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+
+        return completionSource.Task;
+    }
+
+    private sealed class PumpingSynchronizationContext : SynchronizationContext
+    {
+        private readonly Queue<(SendOrPostCallback Callback, object? State)> _workItems = new();
+        private readonly AutoResetEvent _workItemsWaiting = new(false);
+        private readonly int _threadId = Environment.CurrentManagedThreadId;
+        private bool _completed;
+
+        public override void Post(SendOrPostCallback d, object? state)
+        {
+            lock (_workItems)
+            {
+                _workItems.Enqueue((d, state));
+            }
+
+            _workItemsWaiting.Set();
+        }
+
+        public override void Send(SendOrPostCallback d, object? state)
+        {
+            if (Environment.CurrentManagedThreadId == _threadId)
+            {
+                d(state);
+                return;
+            }
+
+            using var completed = new ManualResetEventSlim();
+            Exception? capturedException = null;
+            Post(_ =>
+            {
+                try
+                {
+                    d(state);
+                }
+                catch (Exception ex)
+                {
+                    capturedException = ex;
+                }
+                finally
+                {
+                    completed.Set();
+                }
+            }, null);
+
+            completed.Wait();
+
+            if (capturedException is not null)
+            {
+                throw capturedException;
+            }
+        }
+
+        public void Complete()
+        {
+            _completed = true;
+            _workItemsWaiting.Set();
+        }
+
+        public void RunOnCurrentThread()
+        {
+            while (true)
+            {
+                (SendOrPostCallback Callback, object? State)? workItem = null;
+
+                lock (_workItems)
+                {
+                    if (_workItems.Count > 0)
+                    {
+                        workItem = _workItems.Dequeue();
+                    }
+                    else if (_completed)
+                    {
+                        return;
+                    }
+                }
+
+                if (workItem is { } item)
+                {
+                    item.Callback(item.State);
+                    continue;
+                }
+
+                _workItemsWaiting.WaitOne();
+            }
+        }
+    }
+}

--- a/tests/SpeechTranslator.Desktop.Tests/RecordingFileServiceTests.cs
+++ b/tests/SpeechTranslator.Desktop.Tests/RecordingFileServiceTests.cs
@@ -1,0 +1,78 @@
+using System.Text;
+using SpeechTranslatorDesktop.Services;
+
+namespace SpeechTranslator.Desktop.Tests;
+
+public class RecordingFileServiceTests : IDisposable
+{
+    private readonly string _rootDirectory = Path.Combine(AppContext.BaseDirectory, "recording-tests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void AppendTranslation_FileNameProvided_WritesUtf8Recording()
+    {
+        var service = new RecordingFileService(_rootDirectory);
+
+        service.AppendTranslation("session-01", "hello", "こんにちは");
+
+        var filePath = Path.Combine(_rootDirectory, "recordings", "session-01.txt");
+        File.Exists(filePath).Should().BeTrue();
+        File.ReadAllText(filePath, Encoding.UTF8).Should().Contain("hello").And.Contain("こんにちは");
+    }
+
+    [Fact]
+    public void AppendTranslation_EmptyFileName_DoesNotCreateRecording()
+    {
+        var service = new RecordingFileService(_rootDirectory);
+
+        service.AppendTranslation(string.Empty, "hello", "こんにちは");
+
+        Directory.Exists(Path.Combine(_rootDirectory, "recordings")).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(@"C:\escape")]
+    [InlineData("..\\escape")]
+    [InlineData("../escape")]
+    [InlineData("nested/file")]
+    [InlineData("nested\\file")]
+    [InlineData("session.txt")]
+    [InlineData("session 01")]
+    [InlineData("..")]
+    public void AppendTranslation_InvalidFileName_ThrowsArgumentException(string fileName)
+    {
+        var service = new RecordingFileService(_rootDirectory);
+
+        var act = () => service.AppendTranslation(fileName, "hello", "こんにちは");
+
+        act.Should().Throw<ArgumentException>();
+        Directory.Exists(Path.Combine(_rootDirectory, "recordings")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NormalizeFileName_ValidFileName_ReturnsTrimmedValue()
+    {
+        var service = new RecordingFileService(_rootDirectory);
+
+        var normalized = service.NormalizeFileName(" session-01 ");
+
+        normalized.Should().Be("session-01");
+    }
+
+    [Fact]
+    public void NormalizeFileName_WhitespaceOnly_ReturnsNull()
+    {
+        var service = new RecordingFileService(_rootDirectory);
+
+        var normalized = service.NormalizeFileName("   ");
+
+        normalized.Should().BeNull();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_rootDirectory))
+        {
+            Directory.Delete(_rootDirectory, recursive: true);
+        }
+    }
+}

--- a/tests/SpeechTranslator.Desktop.Tests/SpeechTranslator.Desktop.Tests.csproj
+++ b/tests/SpeechTranslator.Desktop.Tests/SpeechTranslator.Desktop.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="8.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SpeechTranslatorDesktop\SpeechTranslatorDesktop.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## 概要
- 既存のコンソールアプリと同等の通訳/翻訳機能を持つ WPF デスクトップアプリを追加
- Azure AI Speech の認証情報を SPEECH_REGION / SPEECH_KEY の環境変数から読み込むよう追加
- 共有 Translator をセッション開始/停止できるよう拡張
- README と solution、デスクトップ向けテストを更新

## 変更内容
- src/SpeechTranslatorDesktop を追加
  - 開始/停止操作、言語選択、翻訳ログ表示、記録ファイル保存を実装
- SpeechTranslatorShared に ITranslationSession / TranslationSession を追加
- Translator.StartTranslationAsync を追加し、継続認識の開始/停止制御を共通化
- 	ests/SpeechTranslator.Desktop.Tests を追加
- speech-translator.sln と README.md を更新

## テスト
- dotnet test speech-translator.sln --no-restore

## 補足
- デスクトップアプリは Azure AI Speech の認証情報を環境変数のみから取得します
- 記録ファイルは実行ディレクトリ配下の ecordings/ に UTF-8 テキストで保存されます

Closes #20