### PR TITLE
Add Azure AI Service settings persistence to desktop app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,6 +233,9 @@ _pkginfo.txt
 ClientBin/
 ~$*
 *~
+speech-translator-desktop.db
+speech-translator-desktop.db-shm
+speech-translator-desktop.db-wal
 *.dbmdl
 *.dbproj.schemaview
 *.jfm

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -28,22 +28,24 @@ This app is speech translator and recorder using [Azure AI Speech](https://azure
 
 ### Desktop app (WPF)
 
-Desktop app reads Azure AI Speech credentials from environment variables only.
-
 1. Create Azure AI Speech resource. ([Bicep](./infra/main.bicep))
 2. Set the microphone device for translation as the default input device.
-3. Set environment variables in PowerShell.
+3. Run the desktop project.
+   ```powershell
+   dotnet run --project src/SpeechTranslatorDesktop
+   ```
+4. In the `Azure AI Service 設定` section, enter the Azure AI Speech `Region` and `API Key`, then click `保存`.
+   - Settings are stored in SQLite at `%LocalAppData%\SpeechTranslatorDesktop\speech-translator-desktop.db`.
+   - The API key is protected with Windows DPAPI before it is written to SQLite.
+   - Saved settings are automatically loaded the next time the app starts.
+5. If you do not save settings in the app, the desktop app falls back to the `SPEECH_REGION` and `SPEECH_KEY` environment variables.
    ```powershell
    $env:SPEECH_REGION="japaneast"
    $env:SPEECH_KEY="your-speech-key"
    ```
-4. Run the desktop project.
-   ```powershell
-   dotnet run --project src/SpeechTranslatorDesktop
-   ```
-5. Select the speaker language and target language.
-6. Optionally enter a simple recording file name stem (letters/numbers/`-`/`_`, no path or extension). If empty, no file is saved.
-7. Click `開始` to start and `停止` to stop.
+6. Select the speaker language and target language.
+7. Optionally enter a simple recording file name stem (letters/numbers/`-`/`_`, no path or extension). If empty, no file is saved.
+8. Click `開始` to start and `停止` to stop.
 
 Recording files are saved as UTF-8 text files under `recordings/` relative to the desktop app executable directory.
 

--- a/src/SpeechTranslatorDesktop/Behaviors/PasswordBoxBindingBehavior.cs
+++ b/src/SpeechTranslatorDesktop/Behaviors/PasswordBoxBindingBehavior.cs
@@ -1,0 +1,56 @@
+namespace SpeechTranslatorDesktop.Behaviors;
+
+public static class PasswordBoxBindingBehavior
+{
+    private static readonly DependencyProperty IsUpdatingProperty = DependencyProperty.RegisterAttached(
+        "IsUpdating",
+        typeof(bool),
+        typeof(PasswordBoxBindingBehavior));
+
+    public static readonly DependencyProperty BoundPasswordProperty = DependencyProperty.RegisterAttached(
+        "BoundPassword",
+        typeof(string),
+        typeof(PasswordBoxBindingBehavior),
+        new FrameworkPropertyMetadata(string.Empty, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnBoundPasswordChanged));
+
+    public static string GetBoundPassword(DependencyObject dependencyObject)
+    {
+        ArgumentNullException.ThrowIfNull(dependencyObject);
+        return (string)dependencyObject.GetValue(BoundPasswordProperty);
+    }
+
+    public static void SetBoundPassword(DependencyObject dependencyObject, string value)
+    {
+        ArgumentNullException.ThrowIfNull(dependencyObject);
+        dependencyObject.SetValue(BoundPasswordProperty, value);
+    }
+
+    private static void OnBoundPasswordChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+    {
+        if (dependencyObject is not PasswordBox passwordBox)
+        {
+            return;
+        }
+
+        passwordBox.PasswordChanged -= HandlePasswordChanged;
+
+        if (!(bool)passwordBox.GetValue(IsUpdatingProperty))
+        {
+            passwordBox.Password = e.NewValue as string ?? string.Empty;
+        }
+
+        passwordBox.PasswordChanged += HandlePasswordChanged;
+    }
+
+    private static void HandlePasswordChanged(object sender, RoutedEventArgs e)
+    {
+        if (sender is not PasswordBox passwordBox)
+        {
+            return;
+        }
+
+        passwordBox.SetValue(IsUpdatingProperty, true);
+        SetBoundPassword(passwordBox, passwordBox.Password);
+        passwordBox.SetValue(IsUpdatingProperty, false);
+    }
+}

--- a/src/SpeechTranslatorDesktop/Behaviors/PasswordBoxBindingBehavior.cs
+++ b/src/SpeechTranslatorDesktop/Behaviors/PasswordBoxBindingBehavior.cs
@@ -2,27 +2,67 @@ namespace SpeechTranslatorDesktop.Behaviors;
 
 public static class PasswordBoxBindingBehavior
 {
+    private static readonly DependencyProperty IsSubscribedProperty = DependencyProperty.RegisterAttached(
+        "IsSubscribed",
+        typeof(bool),
+        typeof(PasswordBoxBindingBehavior));
+
     private static readonly DependencyProperty IsUpdatingProperty = DependencyProperty.RegisterAttached(
         "IsUpdating",
         typeof(bool),
         typeof(PasswordBoxBindingBehavior));
 
+    public static readonly DependencyProperty AttachProperty = DependencyProperty.RegisterAttached(
+        "Attach",
+        typeof(bool),
+        typeof(PasswordBoxBindingBehavior),
+        new PropertyMetadata(false, OnAttachChanged));
+
     public static readonly DependencyProperty BoundPasswordProperty = DependencyProperty.RegisterAttached(
         "BoundPassword",
         typeof(string),
         typeof(PasswordBoxBindingBehavior),
-        new FrameworkPropertyMetadata(string.Empty, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnBoundPasswordChanged));
+        new FrameworkPropertyMetadata(default(string), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnBoundPasswordChanged));
+
+    public static bool GetAttach(DependencyObject dependencyObject)
+    {
+        ArgumentNullException.ThrowIfNull(dependencyObject);
+        return (bool)dependencyObject.GetValue(AttachProperty);
+    }
+
+    public static void SetAttach(DependencyObject dependencyObject, bool value)
+    {
+        ArgumentNullException.ThrowIfNull(dependencyObject);
+        dependencyObject.SetValue(AttachProperty, value);
+    }
 
     public static string GetBoundPassword(DependencyObject dependencyObject)
     {
         ArgumentNullException.ThrowIfNull(dependencyObject);
-        return (string)dependencyObject.GetValue(BoundPasswordProperty);
+        return dependencyObject.GetValue(BoundPasswordProperty) as string ?? string.Empty;
     }
 
     public static void SetBoundPassword(DependencyObject dependencyObject, string value)
     {
         ArgumentNullException.ThrowIfNull(dependencyObject);
         dependencyObject.SetValue(BoundPasswordProperty, value);
+    }
+
+    private static void OnAttachChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+    {
+        if (dependencyObject is not PasswordBox passwordBox)
+        {
+            return;
+        }
+
+        if (e.NewValue is true)
+        {
+            EnsureSubscribed(passwordBox);
+            UpdatePasswordBox(passwordBox, GetBoundPassword(passwordBox));
+            return;
+        }
+
+        EnsureUnsubscribed(passwordBox);
     }
 
     private static void OnBoundPasswordChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
@@ -32,14 +72,44 @@ public static class PasswordBoxBindingBehavior
             return;
         }
 
-        passwordBox.PasswordChanged -= HandlePasswordChanged;
-
         if (!(bool)passwordBox.GetValue(IsUpdatingProperty))
         {
-            passwordBox.Password = e.NewValue as string ?? string.Empty;
+            UpdatePasswordBox(passwordBox, e.NewValue as string ?? string.Empty);
+        }
+
+        EnsureSubscribed(passwordBox);
+    }
+
+    private static void EnsureSubscribed(PasswordBox passwordBox)
+    {
+        if ((bool)passwordBox.GetValue(IsSubscribedProperty))
+        {
+            return;
         }
 
         passwordBox.PasswordChanged += HandlePasswordChanged;
+        passwordBox.SetValue(IsSubscribedProperty, true);
+    }
+
+    private static void EnsureUnsubscribed(PasswordBox passwordBox)
+    {
+        if (!(bool)passwordBox.GetValue(IsSubscribedProperty))
+        {
+            return;
+        }
+
+        passwordBox.PasswordChanged -= HandlePasswordChanged;
+        passwordBox.SetValue(IsSubscribedProperty, false);
+    }
+
+    private static void UpdatePasswordBox(PasswordBox passwordBox, string password)
+    {
+        if (passwordBox.Password == password)
+        {
+            return;
+        }
+
+        passwordBox.Password = password;
     }
 
     private static void HandlePasswordChanged(object sender, RoutedEventArgs e)

--- a/src/SpeechTranslatorDesktop/MainWindow.xaml
+++ b/src/SpeechTranslatorDesktop/MainWindow.xaml
@@ -12,6 +12,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
@@ -46,10 +47,62 @@
                      Text="{Binding RecordingFileName, UpdateSourceTrigger=PropertyChanged}" />
         </StackPanel>
 
-        <StackPanel Grid.Row="2"
-                    Grid.ColumnSpan="2"
-                    Orientation="Horizontal"
-                    Margin="0,0,0,12">
+        <GroupBox Grid.Row="2"
+                  Grid.ColumnSpan="2"
+                  Header="Azure AI Service 設定"
+                  Margin="0,0,0,12">
+            <Grid Margin="12">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Grid.Row="0"
+                           Grid.Column="0"
+                           Margin="0,0,12,8"
+                           VerticalAlignment="Center"
+                           FontWeight="Bold"
+                           Text="Region" />
+                <TextBox Grid.Row="0"
+                         Grid.Column="1"
+                         Margin="0,0,12,8"
+                         Text="{Binding AzureRegion, UpdateSourceTrigger=PropertyChanged}" />
+
+                <TextBlock Grid.Row="1"
+                           Grid.Column="0"
+                           Margin="0,0,12,8"
+                           VerticalAlignment="Center"
+                           FontWeight="Bold"
+                           Text="API Key" />
+                <PasswordBox Grid.Row="1"
+                             Grid.Column="1"
+                             Margin="0,0,12,8"
+                             local:PasswordBoxBindingBehavior.BoundPassword="{Binding AzureApiKey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+                <Button Grid.Row="0"
+                        Grid.RowSpan="2"
+                        Grid.Column="2"
+                        Width="120"
+                        Command="{Binding SaveSettingsCommand}"
+                        Content="保存" />
+
+                <TextBlock Grid.Row="2"
+                           Grid.ColumnSpan="3"
+                           Text="{Binding SettingsStatusMessage}"
+                           TextWrapping="Wrap" />
+            </Grid>
+        </GroupBox>
+
+        <StackPanel Grid.Row="3"
+                     Grid.ColumnSpan="2"
+                     Orientation="Horizontal"
+                     Margin="0,0,0,12">
             <Button Width="120"
                     Command="{Binding StartCommand}"
                     Content="開始" />
@@ -63,7 +116,7 @@
                        Text="{Binding StatusMessage}" />
         </StackPanel>
 
-        <GroupBox Grid.Row="3"
+        <GroupBox Grid.Row="4"
                   Grid.ColumnSpan="2"
                   Header="翻訳ログ"
                   Margin="0,0,0,12">
@@ -83,7 +136,7 @@
             </DataGrid>
         </GroupBox>
 
-        <GroupBox Grid.Row="4"
+        <GroupBox Grid.Row="5"
                   Grid.ColumnSpan="2"
                   Header="状態ログ">
             <ListBox ItemsSource="{Binding ActivityLogs}"

--- a/src/SpeechTranslatorDesktop/MainWindow.xaml
+++ b/src/SpeechTranslatorDesktop/MainWindow.xaml
@@ -80,10 +80,11 @@
                            VerticalAlignment="Center"
                            FontWeight="Bold"
                            Text="API Key" />
-                <PasswordBox Grid.Row="1"
-                             Grid.Column="1"
-                             Margin="0,0,12,8"
-                             local:PasswordBoxBindingBehavior.BoundPassword="{Binding AzureApiKey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                 <PasswordBox Grid.Row="1"
+                              Grid.Column="1"
+                              Margin="0,0,12,8"
+                              local:PasswordBoxBindingBehavior.Attach="True"
+                              local:PasswordBoxBindingBehavior.BoundPassword="{Binding AzureApiKey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                 <Button Grid.Row="0"
                         Grid.RowSpan="2"

--- a/src/SpeechTranslatorDesktop/MainWindow.xaml.cs
+++ b/src/SpeechTranslatorDesktop/MainWindow.xaml.cs
@@ -9,11 +9,16 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         var recordingFileService = new RecordingFileService(AppContext.BaseDirectory);
-        DataContext = new MainViewModel(
+        var viewModel = new MainViewModel(
             new WpfUiDispatcher(),
             new EnvironmentSpeechCredentialsProvider(),
+            new SqliteAzureAiServiceSettingsStore(
+                SpeechSettingsPathProvider.GetDatabasePath(),
+                new DpapiSecretProtector()),
             recordingFileService,
             new DesktopTranslationController(),
             new DesktopTranslationWorkerFactory(recordingFileService));
+        DataContext = viewModel;
+        Loaded += async (_, _) => await viewModel.InitializeAsync();
     }
 }

--- a/src/SpeechTranslatorDesktop/Services/AzureAiServiceSettings.cs
+++ b/src/SpeechTranslatorDesktop/Services/AzureAiServiceSettings.cs
@@ -1,0 +1,3 @@
+namespace SpeechTranslatorDesktop.Services;
+
+public sealed record AzureAiServiceSettings(string Region, string ApiKey);

--- a/src/SpeechTranslatorDesktop/Services/DpapiSecretProtector.cs
+++ b/src/SpeechTranslatorDesktop/Services/DpapiSecretProtector.cs
@@ -1,0 +1,20 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace SpeechTranslatorDesktop.Services;
+
+public sealed class DpapiSecretProtector : ISecretProtector
+{
+    public byte[] Protect(string plaintext)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(plaintext);
+        return ProtectedData.Protect(Encoding.UTF8.GetBytes(plaintext), optionalEntropy: null, DataProtectionScope.CurrentUser);
+    }
+
+    public string Unprotect(byte[] protectedData)
+    {
+        ArgumentNullException.ThrowIfNull(protectedData);
+        var plaintextBytes = ProtectedData.Unprotect(protectedData, optionalEntropy: null, DataProtectionScope.CurrentUser);
+        return Encoding.UTF8.GetString(plaintextBytes);
+    }
+}

--- a/src/SpeechTranslatorDesktop/Services/EnvironmentSpeechCredentialsProvider.cs
+++ b/src/SpeechTranslatorDesktop/Services/EnvironmentSpeechCredentialsProvider.cs
@@ -9,10 +9,10 @@ public sealed class EnvironmentSpeechCredentialsProvider : ISpeechCredentialsPro
         _environmentReader = environmentReader ?? Environment.GetEnvironmentVariable;
     }
 
-    public SpeechCredentialsResult GetCredentials()
+    public SpeechCredentialsResult GetCredentials(string? preferredRegion = null, string? preferredKey = null)
     {
-        var region = _environmentReader("SPEECH_REGION");
-        var key = _environmentReader("SPEECH_KEY");
+        var region = string.IsNullOrWhiteSpace(preferredRegion) ? _environmentReader("SPEECH_REGION") : preferredRegion.Trim();
+        var key = string.IsNullOrWhiteSpace(preferredKey) ? _environmentReader("SPEECH_KEY") : preferredKey.Trim();
         var missingVariables = new List<string>();
 
         if (string.IsNullOrWhiteSpace(region))
@@ -27,9 +27,12 @@ public sealed class EnvironmentSpeechCredentialsProvider : ISpeechCredentialsPro
 
         if (missingVariables.Count > 0)
         {
-            return SpeechCredentialsResult.Failure($"Required environment variables are missing: {string.Join(", ", missingVariables)}");
+            return SpeechCredentialsResult.Failure($"Azure AI Service の認証情報が未設定です。設定画面で保存するか、環境変数を設定してください: {string.Join(", ", missingVariables)}");
         }
 
-        return SpeechCredentialsResult.Success(new SpeechCredentials(region!, key!));
+        var normalizedRegion = region!.Trim();
+        var normalizedKey = key!.Trim();
+
+        return SpeechCredentialsResult.Success(new SpeechCredentials(normalizedRegion, normalizedKey));
     }
 }

--- a/src/SpeechTranslatorDesktop/Services/IAzureAiServiceSettingsStore.cs
+++ b/src/SpeechTranslatorDesktop/Services/IAzureAiServiceSettingsStore.cs
@@ -1,0 +1,8 @@
+namespace SpeechTranslatorDesktop.Services;
+
+public interface IAzureAiServiceSettingsStore
+{
+    Task<AzureAiServiceSettings?> LoadAsync(CancellationToken cancellationToken = default);
+
+    Task SaveAsync(AzureAiServiceSettings settings, CancellationToken cancellationToken = default);
+}

--- a/src/SpeechTranslatorDesktop/Services/ISecretProtector.cs
+++ b/src/SpeechTranslatorDesktop/Services/ISecretProtector.cs
@@ -1,0 +1,8 @@
+namespace SpeechTranslatorDesktop.Services;
+
+public interface ISecretProtector
+{
+    byte[] Protect(string plaintext);
+
+    string Unprotect(byte[] protectedData);
+}

--- a/src/SpeechTranslatorDesktop/Services/ISpeechCredentialsProvider.cs
+++ b/src/SpeechTranslatorDesktop/Services/ISpeechCredentialsProvider.cs
@@ -2,5 +2,5 @@ namespace SpeechTranslatorDesktop.Services;
 
 public interface ISpeechCredentialsProvider
 {
-    SpeechCredentialsResult GetCredentials();
+    SpeechCredentialsResult GetCredentials(string? preferredRegion = null, string? preferredKey = null);
 }

--- a/src/SpeechTranslatorDesktop/Services/SpeechSettingsPathProvider.cs
+++ b/src/SpeechTranslatorDesktop/Services/SpeechSettingsPathProvider.cs
@@ -1,0 +1,10 @@
+namespace SpeechTranslatorDesktop.Services;
+
+public static class SpeechSettingsPathProvider
+{
+    public static string GetDatabasePath()
+    {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        return Path.Combine(localAppData, "SpeechTranslatorDesktop", "speech-translator-desktop.db");
+    }
+}

--- a/src/SpeechTranslatorDesktop/Services/SqliteAzureAiServiceSettingsStore.cs
+++ b/src/SpeechTranslatorDesktop/Services/SqliteAzureAiServiceSettingsStore.cs
@@ -1,0 +1,105 @@
+using Microsoft.Data.Sqlite;
+
+namespace SpeechTranslatorDesktop.Services;
+
+public sealed class SqliteAzureAiServiceSettingsStore : IAzureAiServiceSettingsStore
+{
+    private const string TableName = "azure_ai_service_settings";
+    private readonly string _databasePath;
+    private readonly ISecretProtector _secretProtector;
+
+    public SqliteAzureAiServiceSettingsStore(string databasePath, ISecretProtector secretProtector)
+    {
+        if (string.IsNullOrWhiteSpace(databasePath))
+        {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(databasePath));
+        }
+
+        _databasePath = databasePath;
+        _secretProtector = secretProtector ?? throw new ArgumentNullException(nameof(secretProtector));
+    }
+
+    public async Task<AzureAiServiceSettings?> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(_databasePath))
+        {
+            return null;
+        }
+
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        await EnsureSchemaAsync(connection, cancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"""
+            SELECT region, protected_api_key
+            FROM {TableName}
+            WHERE id = 1;
+            """;
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return null;
+        }
+
+        var region = reader.GetString(0);
+        var protectedApiKey = (byte[])reader["protected_api_key"];
+        var apiKey = _secretProtector.Unprotect(protectedApiKey);
+
+        return new AzureAiServiceSettings(region, apiKey);
+    }
+
+    public async Task SaveAsync(AzureAiServiceSettings settings, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        var directoryPath = Path.GetDirectoryName(_databasePath);
+        if (!string.IsNullOrWhiteSpace(directoryPath))
+        {
+            Directory.CreateDirectory(directoryPath);
+        }
+
+        await using var connection = await OpenConnectionAsync(cancellationToken);
+        await EnsureSchemaAsync(connection, cancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"""
+            INSERT INTO {TableName} (id, region, protected_api_key)
+            VALUES (1, $region, $protectedApiKey)
+            ON CONFLICT(id) DO UPDATE SET
+                region = excluded.region,
+                protected_api_key = excluded.protected_api_key;
+            """;
+        command.Parameters.AddWithValue("$region", settings.Region);
+        command.Parameters.Add("$protectedApiKey", SqliteType.Blob).Value = _secretProtector.Protect(settings.ApiKey);
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connectionStringBuilder = new SqliteConnectionStringBuilder
+        {
+            DataSource = _databasePath,
+            Pooling = false
+        };
+
+        var connection = new SqliteConnection(connectionStringBuilder.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+        return connection;
+    }
+
+    private static async Task EnsureSchemaAsync(SqliteConnection connection, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"""
+            CREATE TABLE IF NOT EXISTS {TableName} (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                region TEXT NOT NULL,
+                protected_api_key BLOB NOT NULL
+            );
+            """;
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+}

--- a/src/SpeechTranslatorDesktop/SpeechTranslatorDesktop.csproj
+++ b/src/SpeechTranslatorDesktop/SpeechTranslatorDesktop.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0-preview.7.25380.108" />
     <ProjectReference Include="..\Shared\SpeechTranslatorShared.csproj" />
   </ItemGroup>
 

--- a/src/SpeechTranslatorDesktop/SpeechTranslatorDesktop.csproj
+++ b/src/SpeechTranslatorDesktop/SpeechTranslatorDesktop.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0-preview.7.25380.108" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <ProjectReference Include="..\Shared\SpeechTranslatorShared.csproj" />
   </ItemGroup>
 

--- a/src/SpeechTranslatorDesktop/ViewModels/MainViewModel.cs
+++ b/src/SpeechTranslatorDesktop/ViewModels/MainViewModel.cs
@@ -8,25 +8,31 @@ public sealed class MainViewModel : INotifyPropertyChanged
 {
     private readonly IUiDispatcher _dispatcher;
     private readonly ISpeechCredentialsProvider _credentialsProvider;
+    private readonly IAzureAiServiceSettingsStore _settingsStore;
     private readonly IRecordingFileService _recordingFileService;
     private readonly ITranslationController _translationController;
     private readonly IDesktopTranslationWorkerFactory _workerFactory;
     private IDesktopTranslationWorker? _currentWorker;
     private LanguageOption? _selectedSourceLanguage;
     private LanguageOption? _selectedTargetLanguage;
+    private string _azureApiKey = string.Empty;
+    private string _azureRegion = string.Empty;
     private string _recordingFileName = string.Empty;
+    private string _settingsStatusMessage = string.Empty;
     private string _statusMessage = "停止";
     private bool _isRunning;
 
     public MainViewModel(
         IUiDispatcher dispatcher,
         ISpeechCredentialsProvider credentialsProvider,
+        IAzureAiServiceSettingsStore settingsStore,
         IRecordingFileService recordingFileService,
         ITranslationController translationController,
         IDesktopTranslationWorkerFactory workerFactory)
     {
         _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
         _credentialsProvider = credentialsProvider ?? throw new ArgumentNullException(nameof(credentialsProvider));
+        _settingsStore = settingsStore ?? throw new ArgumentNullException(nameof(settingsStore));
         _recordingFileService = recordingFileService ?? throw new ArgumentNullException(nameof(recordingFileService));
         _translationController = translationController ?? throw new ArgumentNullException(nameof(translationController));
         _workerFactory = workerFactory ?? throw new ArgumentNullException(nameof(workerFactory));
@@ -42,6 +48,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
 
         StartCommand = new AsyncRelayCommand(StartAsync, () => !IsRunning, _dispatcher, HandleCommandException);
         StopCommand = new AsyncRelayCommand(StopAsync, () => IsRunning, _dispatcher, HandleCommandException);
+        SaveSettingsCommand = new AsyncRelayCommand(SaveSettingsAsync, dispatcher: _dispatcher, onException: HandleSettingsCommandException);
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -49,6 +56,36 @@ public sealed class MainViewModel : INotifyPropertyChanged
     public ObservableCollection<string> ActivityLogs { get; } = [];
 
     public ObservableCollection<LanguageOption> AvailableLanguages { get; }
+
+    public string AzureApiKey
+    {
+        get => _azureApiKey;
+        set
+        {
+            if (_azureApiKey == value)
+            {
+                return;
+            }
+
+            _azureApiKey = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string AzureRegion
+    {
+        get => _azureRegion;
+        set
+        {
+            if (_azureRegion == value)
+            {
+                return;
+            }
+
+            _azureRegion = value;
+            OnPropertyChanged();
+        }
+    }
 
     public bool IsRunning
     {
@@ -114,6 +151,23 @@ public sealed class MainViewModel : INotifyPropertyChanged
 
     public AsyncRelayCommand StartCommand { get; }
 
+    public AsyncRelayCommand SaveSettingsCommand { get; }
+
+    public string SettingsStatusMessage
+    {
+        get => _settingsStatusMessage;
+        private set
+        {
+            if (_settingsStatusMessage == value)
+            {
+                return;
+            }
+
+            _settingsStatusMessage = value;
+            OnPropertyChanged();
+        }
+    }
+
     public string StatusMessage
     {
         get => _statusMessage;
@@ -132,6 +186,28 @@ public sealed class MainViewModel : INotifyPropertyChanged
     public AsyncRelayCommand StopCommand { get; }
 
     public ObservableCollection<TranslationLogItem> TranslationLogs { get; } = [];
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var savedSettings = await _settingsStore.LoadAsync(cancellationToken);
+            if (savedSettings is null)
+            {
+                SettingsStatusMessage = "Azure AI Service のリージョンと API キーを入力して保存してください。未保存の場合は SPEECH_REGION / SPEECH_KEY をフォールバックとして使用します。";
+                return;
+            }
+
+            AzureRegion = savedSettings.Region;
+            AzureApiKey = savedSettings.ApiKey;
+            SettingsStatusMessage = "保存済みの Azure AI Service 設定を読み込みました。";
+        }
+        catch (Exception ex)
+        {
+            SettingsStatusMessage = $"設定の読み込みに失敗しました: {ex.Message}";
+            AddActivityLog(SettingsStatusMessage);
+        }
+    }
 
     private async Task StartAsync()
     {
@@ -154,7 +230,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
             return;
         }
 
-        var credentialsResult = _credentialsProvider.GetCredentials();
+        var credentialsResult = _credentialsProvider.GetCredentials(AzureRegion, AzureApiKey);
         if (!credentialsResult.IsValid || credentialsResult.Credentials is null)
         {
             StatusMessage = credentialsResult.ErrorMessage;
@@ -184,6 +260,25 @@ public sealed class MainViewModel : INotifyPropertyChanged
             StatusMessage = ex.Message;
             AddActivityLog(ex.Message);
         }
+    }
+
+    private async Task SaveSettingsAsync()
+    {
+        var normalizedRegion = AzureRegion.Trim();
+        var normalizedApiKey = AzureApiKey.Trim();
+
+        if (string.IsNullOrWhiteSpace(normalizedRegion) || string.IsNullOrWhiteSpace(normalizedApiKey))
+        {
+            SettingsStatusMessage = "Azure AI Service のリージョンと API キーを入力してから保存してください。";
+            return;
+        }
+
+        await _settingsStore.SaveAsync(new AzureAiServiceSettings(normalizedRegion, normalizedApiKey));
+
+        AzureRegion = normalizedRegion;
+        AzureApiKey = normalizedApiKey;
+        SettingsStatusMessage = "Azure AI Service 設定を保存しました。";
+        AddActivityLog("Azure AI Service 設定を保存しました。");
     }
 
     private async Task StopAsync()
@@ -294,6 +389,15 @@ public sealed class MainViewModel : INotifyPropertyChanged
             {
                 DetachCurrentWorker();
             }
+        });
+    }
+
+    private void HandleSettingsCommandException(Exception ex)
+    {
+        _dispatcher.Invoke(() =>
+        {
+            SettingsStatusMessage = $"設定の保存に失敗しました: {ex.Message}";
+            AddActivityLog(SettingsStatusMessage);
         });
     }
 

--- a/tests/SpeechTranslator.Desktop.Tests/EnvironmentSpeechCredentialsProviderTests.cs
+++ b/tests/SpeechTranslator.Desktop.Tests/EnvironmentSpeechCredentialsProviderTests.cs
@@ -22,6 +22,42 @@ public class EnvironmentSpeechCredentialsProviderTests
         result.Credentials.Key.Should().Be("test-key");
     }
 
+    [Fact]
+    public void GetCredentials_PrefersConfiguredValuesOverEnvironmentVariables()
+    {
+        var provider = new EnvironmentSpeechCredentialsProvider(name => name switch
+        {
+            "SPEECH_REGION" => "env-region",
+            "SPEECH_KEY" => "env-key",
+            _ => null
+        });
+
+        var result = provider.GetCredentials("configured-region", "configured-key");
+
+        result.IsValid.Should().BeTrue();
+        result.Credentials.Should().NotBeNull();
+        result.Credentials!.Region.Should().Be("configured-region");
+        result.Credentials.Key.Should().Be("configured-key");
+    }
+
+    [Fact]
+    public void GetCredentials_WhenConfiguredValuesMissing_FallsBackToEnvironmentVariables()
+    {
+        var provider = new EnvironmentSpeechCredentialsProvider(name => name switch
+        {
+            "SPEECH_REGION" => "env-region",
+            "SPEECH_KEY" => "env-key",
+            _ => null
+        });
+
+        var result = provider.GetCredentials("", null);
+
+        result.IsValid.Should().BeTrue();
+        result.Credentials.Should().NotBeNull();
+        result.Credentials!.Region.Should().Be("env-region");
+        result.Credentials.Key.Should().Be("env-key");
+    }
+
     [Theory]
     [InlineData(null, "test-key", "SPEECH_REGION")]
     [InlineData("japaneast", null, "SPEECH_KEY")]

--- a/tests/SpeechTranslator.Desktop.Tests/GlobalUsings.cs
+++ b/tests/SpeechTranslator.Desktop.Tests/GlobalUsings.cs
@@ -1,5 +1,6 @@
 global using FluentAssertions;
 global using Microsoft.CognitiveServices.Speech;
 global using Microsoft.CognitiveServices.Speech.Translation;
+global using System.IO;
 global using System.Text;
 global using Xunit;

--- a/tests/SpeechTranslator.Desktop.Tests/GlobalUsings.cs
+++ b/tests/SpeechTranslator.Desktop.Tests/GlobalUsings.cs
@@ -1,4 +1,5 @@
 global using FluentAssertions;
 global using Microsoft.CognitiveServices.Speech;
 global using Microsoft.CognitiveServices.Speech.Translation;
+global using System.Text;
 global using Xunit;

--- a/tests/SpeechTranslator.Desktop.Tests/MainViewModelTests.cs
+++ b/tests/SpeechTranslator.Desktop.Tests/MainViewModelTests.cs
@@ -34,6 +34,94 @@ public class MainViewModelTests
     }
 
     [Fact]
+    public async Task InitializeAsync_WhenSavedSettingsExist_LoadsThemIntoViewModel()
+    {
+        var viewModel = CreateViewModel(
+            settingsStore: new FakeAzureAiServiceSettingsStore
+            {
+                LoadedSettings = new AzureAiServiceSettings("japaneast", "saved-key")
+            });
+
+        await viewModel.InitializeAsync();
+
+        viewModel.AzureRegion.Should().Be("japaneast");
+        viewModel.AzureApiKey.Should().Be("saved-key");
+        viewModel.SettingsStatusMessage.Should().Contain("読み込み");
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WhenSavedSettingsDoNotExist_ShowsGuidance()
+    {
+        var viewModel = CreateViewModel();
+
+        await viewModel.InitializeAsync();
+
+        viewModel.AzureRegion.Should().BeEmpty();
+        viewModel.AzureApiKey.Should().BeEmpty();
+        viewModel.SettingsStatusMessage.Should().Contain("保存");
+        viewModel.SettingsStatusMessage.Should().Contain("SPEECH_REGION");
+    }
+
+    [Fact]
+    public async Task InitializeAsync_OnFirstLaunchWithMissingSettingsDatabase_ShowsGuidanceInsteadOfFailure()
+    {
+        var testDirectory = Path.Combine(
+            AppContext.BaseDirectory,
+            "test-artifacts",
+            nameof(MainViewModelTests),
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            var databasePath = Path.Combine(testDirectory, "nested", "speech-translator-desktop.db");
+            var viewModel = CreateViewModel(
+                settingsStore: new SqliteAzureAiServiceSettingsStore(databasePath, new FakeSecretProtector()));
+
+            await viewModel.InitializeAsync();
+
+            viewModel.SettingsStatusMessage.Should().Contain("保存");
+            viewModel.SettingsStatusMessage.Should().Contain("SPEECH_REGION");
+            viewModel.SettingsStatusMessage.Should().NotContain("失敗");
+        }
+        finally
+        {
+            if (Directory.Exists(testDirectory))
+            {
+                Directory.Delete(testDirectory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task SaveSettings_WhenValuesAreValid_PersistsThem()
+    {
+        var settingsStore = new FakeAzureAiServiceSettingsStore();
+        var viewModel = CreateViewModel(settingsStore: settingsStore);
+        viewModel.AzureRegion = "japaneast";
+        viewModel.AzureApiKey = "saved-key";
+
+        await ExecuteAsync(viewModel.SaveSettingsCommand);
+
+        settingsStore.SaveCallCount.Should().Be(1);
+        settingsStore.SavedSettings.Should().BeEquivalentTo(new AzureAiServiceSettings("japaneast", "saved-key"));
+        viewModel.SettingsStatusMessage.Should().Contain("保存");
+    }
+
+    [Fact]
+    public async Task SaveSettings_WhenValuesAreMissing_ShowsValidationError()
+    {
+        var settingsStore = new FakeAzureAiServiceSettingsStore();
+        var viewModel = CreateViewModel(settingsStore: settingsStore);
+        viewModel.AzureRegion = "japaneast";
+        viewModel.AzureApiKey = "";
+
+        await ExecuteAsync(viewModel.SaveSettingsCommand);
+
+        settingsStore.SaveCallCount.Should().Be(0);
+        viewModel.SettingsStatusMessage.Should().Contain("API キー");
+    }
+
+    [Fact]
     public async Task Start_WhenCredentialsPresent_StartsTranslation()
     {
         var translationController = new FakeTranslationController();
@@ -46,6 +134,21 @@ public class MainViewModelTests
         viewModel.IsRunning.Should().BeTrue();
         viewModel.StartCommand.CanExecute(null).Should().BeFalse();
         viewModel.StopCommand.CanExecute(null).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Start_WhenConfiguredCredentialsPresent_PassesThemToController()
+    {
+        var translationController = new FakeTranslationController();
+        var viewModel = CreateViewModel(
+            credentialsProvider: new FakeSpeechCredentialsProvider(SpeechCredentialsResult.Success(new SpeechCredentials("ui-region", "ui-key"))),
+            translationController: translationController);
+        viewModel.AzureRegion = "ui-region";
+        viewModel.AzureApiKey = "ui-key";
+
+        await ExecuteAsync(viewModel.StartCommand);
+
+        translationController.LastStartCredentials.Should().BeEquivalentTo(new SpeechCredentials("ui-region", "ui-key"));
     }
 
     [Fact]
@@ -184,6 +287,7 @@ public class MainViewModelTests
     private static MainViewModel CreateViewModel(
         IUiDispatcher? dispatcher = null,
         ISpeechCredentialsProvider? credentialsProvider = null,
+        IAzureAiServiceSettingsStore? settingsStore = null,
         IRecordingFileService? recordingFileService = null,
         ITranslationController? translationController = null,
         IDesktopTranslationWorkerFactory? workerFactory = null)
@@ -191,6 +295,7 @@ public class MainViewModelTests
         return new MainViewModel(
             dispatcher ?? new ImmediateDispatcher(),
             credentialsProvider ?? new FakeSpeechCredentialsProvider(SpeechCredentialsResult.Success(new SpeechCredentials("japaneast", "test-key"))),
+            settingsStore ?? new FakeAzureAiServiceSettingsStore(),
             recordingFileService ?? new FakeRecordingFileService(),
             translationController ?? new FakeTranslationController(),
             workerFactory ?? new FakeDesktopTranslationWorkerFactory(new FakeDesktopTranslationWorker()));
@@ -215,7 +320,33 @@ public class MainViewModelTests
             _result = result;
         }
 
-        public SpeechCredentialsResult GetCredentials() => _result;
+        public SpeechCredentialsResult GetCredentials(string? preferredRegion = null, string? preferredKey = null) => _result;
+    }
+
+    private sealed class FakeAzureAiServiceSettingsStore : IAzureAiServiceSettingsStore
+    {
+        public AzureAiServiceSettings? LoadedSettings { get; init; }
+        public AzureAiServiceSettings? SavedSettings { get; private set; }
+        public int SaveCallCount { get; private set; }
+
+        public Task<AzureAiServiceSettings?> LoadAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(LoadedSettings);
+        }
+
+        public Task SaveAsync(AzureAiServiceSettings settings, CancellationToken cancellationToken = default)
+        {
+            SaveCallCount++;
+            SavedSettings = settings;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeSecretProtector : ISecretProtector
+    {
+        public byte[] Protect(string plaintext) => Encoding.UTF8.GetBytes(plaintext);
+
+        public string Unprotect(byte[] protectedData) => Encoding.UTF8.GetString(protectedData);
     }
 
     private sealed class FakeTranslationController : ITranslationController
@@ -226,6 +357,7 @@ public class MainViewModelTests
         public bool StartShouldYield { get; init; }
         public Exception? StopException { get; init; }
         public bool KeepRunningOnStopFailure { get; init; }
+        public SpeechCredentials? LastStartCredentials { get; private set; }
 
         public Task StartAsync(SpeechCredentials credentials, string sourceLanguage, string targetLanguage, TranslationRecognizerWorkerBase worker, CancellationToken cancellationToken = default)
         {
@@ -239,6 +371,7 @@ public class MainViewModelTests
                 }
 
                 StartCallCount++;
+                LastStartCredentials = credentials;
                 IsRunning = true;
             }
         }

--- a/tests/SpeechTranslator.Desktop.Tests/PasswordBoxBindingBehaviorTests.cs
+++ b/tests/SpeechTranslator.Desktop.Tests/PasswordBoxBindingBehaviorTests.cs
@@ -1,0 +1,118 @@
+using System.ComponentModel;
+using System.Windows.Controls;
+using System.Windows.Data;
+using SpeechTranslatorDesktop.Behaviors;
+
+namespace SpeechTranslator.Desktop.Tests;
+
+public class PasswordBoxBindingBehaviorTests
+{
+    [Fact]
+    public async Task BoundPassword_WhenInitialValueIsEmpty_UpdatesSourceAndRaisesPropertyChangedOnUserInput()
+    {
+        await RunOnStaThreadAsync(() =>
+        {
+            var source = new BindableSecret();
+            var changedProperties = new List<string?>();
+            source.PropertyChanged += (_, e) => changedProperties.Add(e.PropertyName);
+            var passwordBox = CreateBoundPasswordBox(source);
+
+            passwordBox.Password = "entered-key";
+
+            source.Secret.Should().Be("entered-key");
+            changedProperties.Should().Contain(nameof(BindableSecret.Secret));
+        });
+    }
+
+    [Fact]
+    public async Task BoundPassword_WhenSourceChanges_UpdatesPasswordBox()
+    {
+        await RunOnStaThreadAsync(() =>
+        {
+            var source = new BindableSecret();
+            var passwordBox = CreateBoundPasswordBox(source);
+
+            source.Secret = "loaded-key";
+
+            passwordBox.Password.Should().Be("loaded-key");
+        });
+    }
+
+    [Fact]
+    public async Task BoundPassword_WhenPasswordIsCleared_UpdatesSourceToEmpty()
+    {
+        await RunOnStaThreadAsync(() =>
+        {
+            var source = new BindableSecret { Secret = "loaded-key" };
+            var changedProperties = new List<string?>();
+            source.PropertyChanged += (_, e) => changedProperties.Add(e.PropertyName);
+            var passwordBox = CreateBoundPasswordBox(source);
+
+            passwordBox.Password = string.Empty;
+
+            source.Secret.Should().BeEmpty();
+            changedProperties.Should().Contain(nameof(BindableSecret.Secret));
+        });
+    }
+
+    private static PasswordBox CreateBoundPasswordBox(BindableSecret source)
+    {
+        var passwordBox = new PasswordBox();
+        BindingOperations.SetBinding(
+            passwordBox,
+            PasswordBoxBindingBehavior.BoundPasswordProperty,
+            new Binding(nameof(BindableSecret.Secret))
+            {
+                Source = source,
+                Mode = BindingMode.TwoWay,
+                UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
+            });
+
+        return passwordBox;
+    }
+
+    private static Task RunOnStaThreadAsync(Action testAction)
+    {
+        var completionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                testAction();
+                completionSource.SetResult();
+            }
+            catch (Exception ex)
+            {
+                completionSource.SetException(ex);
+            }
+        });
+
+        thread.IsBackground = true;
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+
+        return completionSource.Task;
+    }
+
+    private sealed class BindableSecret : INotifyPropertyChanged
+    {
+        private string _secret = string.Empty;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public string Secret
+        {
+            get => _secret;
+            set
+            {
+                if (_secret == value)
+                {
+                    return;
+                }
+
+                _secret = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Secret)));
+            }
+        }
+    }
+}

--- a/tests/SpeechTranslator.Desktop.Tests/SpeechTranslator.Desktop.Tests.csproj
+++ b/tests/SpeechTranslator.Desktop.Tests/SpeechTranslator.Desktop.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/SpeechTranslator.Desktop.Tests/SqliteAzureAiServiceSettingsStoreTests.cs
+++ b/tests/SpeechTranslator.Desktop.Tests/SqliteAzureAiServiceSettingsStoreTests.cs
@@ -1,0 +1,100 @@
+using Microsoft.Data.Sqlite;
+using SpeechTranslatorDesktop.Services;
+
+namespace SpeechTranslator.Desktop.Tests;
+
+public class SqliteAzureAiServiceSettingsStoreTests : IDisposable
+{
+    private readonly string _testDirectory;
+
+    public SqliteAzureAiServiceSettingsStoreTests()
+    {
+        _testDirectory = Path.Combine(AppContext.BaseDirectory, "test-artifacts", nameof(SqliteAzureAiServiceSettingsStoreTests), Guid.NewGuid().ToString("N"));
+    }
+
+    [Fact]
+    public async Task SaveAsync_ThenLoadAsync_RoundTripsSettings()
+    {
+        var databasePath = Path.Combine(_testDirectory, "speech-translator-desktop.db");
+        var protector = new FakeSecretProtector();
+        var store = new SqliteAzureAiServiceSettingsStore(databasePath, protector);
+
+        await store.SaveAsync(new AzureAiServiceSettings("japaneast", "plain-text-key"));
+        var settings = await store.LoadAsync();
+
+        settings.Should().NotBeNull();
+        settings!.Region.Should().Be("japaneast");
+        settings.ApiKey.Should().Be("plain-text-key");
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenDirectoryAndDatabaseDoNotExist_ReturnsNull()
+    {
+        var databasePath = Path.Combine(_testDirectory, "nested", "speech-translator-desktop.db");
+        var protector = new FakeSecretProtector();
+        var store = new SqliteAzureAiServiceSettingsStore(databasePath, protector);
+
+        var settings = await store.LoadAsync();
+
+        settings.Should().BeNull();
+        Directory.Exists(Path.GetDirectoryName(databasePath)!).Should().BeFalse();
+        File.Exists(databasePath).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SaveAsync_StoresProtectedApiKeyInsteadOfPlainText()
+    {
+        var databasePath = Path.Combine(_testDirectory, "speech-translator-desktop.db");
+        var protector = new FakeSecretProtector();
+        var store = new SqliteAzureAiServiceSettingsStore(databasePath, protector);
+
+        await store.SaveAsync(new AzureAiServiceSettings("japaneast", "plain-text-key"));
+
+        var connectionStringBuilder = new SqliteConnectionStringBuilder
+        {
+            DataSource = databasePath,
+            Pooling = false
+        };
+
+        await using var connection = new SqliteConnection(connectionStringBuilder.ConnectionString);
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT protected_api_key FROM azure_ai_service_settings WHERE id = 1;";
+        var storedValue = (byte[])(await command.ExecuteScalarAsync())!;
+
+        storedValue.Should().NotBeEmpty();
+        storedValue.Should().NotEqual(Encoding.UTF8.GetBytes("plain-text-key"));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            try
+            {
+                Directory.Delete(_testDirectory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    private sealed class FakeSecretProtector : ISecretProtector
+    {
+        public byte[] Protect(string plaintext)
+        {
+            var plaintextBytes = Encoding.UTF8.GetBytes(plaintext);
+            Array.Reverse(plaintextBytes);
+            return plaintextBytes;
+        }
+
+        public string Unprotect(byte[] protectedData)
+        {
+            var plaintextBytes = protectedData.ToArray();
+            Array.Reverse(plaintextBytes);
+            return Encoding.UTF8.GetString(plaintextBytes);
+        }
+    }
+}


### PR DESCRIPTION
## 背景
- SpeechTranslatorDesktop に Azure AI Service の設定画面を追加しました。
- Region / API Key をアプリ内で保存し、次回起動時に自動ロードできるようにします。
- SQLite/UI の設定を優先し、未設定時は環境変数にフォールバックします。

## 主な変更点
- MainWindow に Azure AI Service 設定セクションを追加し、PasswordBox のバインディングを実装
- Azure AI Service 設定モデル、SQLite ストア、保存先パスプロバイダ、DPAPI ベースのシークレット保護サービスを追加
- MainViewModel に設定の初期ロード、保存、認証情報の解決、初回起動時の未設定ハンドリングを追加
- SQLite ファイルと WAL/SHM を `.gitignore` に追加し、README の Desktop アプリ手順を更新
- Desktop テストを追加・更新し、保存済み設定のロード、環境変数フォールバック、初回起動時の DB 未作成ケースをカバー

## テスト結果
- `dotnet test .\\speech-translator.sln`
  - 成功: 54 / 失敗: 0